### PR TITLE
Yakov/sk rest

### DIFF
--- a/reflex-algos/components/RestModelServing/restful_sklearn_serving/component.json
+++ b/reflex-algos/components/RestModelServing/restful_sklearn_serving/component.json
@@ -13,6 +13,19 @@
   "inputInfo": [],
   "outputInfo": [],
   "arguments": [
+    { "key": "ignore-incompatible-model",
+      "label": "Ignore incompatible model",
+      "description": "If True, Ignore an incompatible model provided to component and continue. If False, faile component ",
+      "type": "boolean",
+      "default": false,
+      "optional": true
+    },
+    { "key": "required-python-version",
+      "label": "Required python version",
+      "description": "If provided, fail if python version used is not the same as required (e.g. 2)",
+      "type": "boolean",
+      "optional": true
+    },
     { "key": "input-model-path",
       "label": "Model input file",
       "type": "str",

--- a/reflex-algos/components/RestModelServing/restful_sklearn_serving/sklearn_restful_serving.py
+++ b/reflex-algos/components/RestModelServing/restful_sklearn_serving/sklearn_restful_serving.py
@@ -1,7 +1,10 @@
 import logging
 import numpy as np
+import sklearn
 import pickle
 import sys
+import pprint
+import os
 
 from parallelm.components.restful.flask_route import FlaskRoute
 from parallelm.components.restful_component import RESTfulComponent
@@ -12,44 +15,96 @@ class SklearnRESTfulServing(RESTfulComponent):
 
     def __init__(self, engine):
         super(SklearnRESTfulServing, self).__init__(engine)
-        self._classifier = None
+        self._model = None
+        self._model_loading_error = None
+        self._params = {}
         self._verbose = self._logger.isEnabledFor(logging.DEBUG)
 
     def load_model_callback(self, model_path, stream, version):
-        self._logger.info("Model is loading, wid: {}, path: {}".format(self.get_wid(), model_path))
-        with open(model_path, "rb") as f:
-            self._classifier = pickle.load(f) if sys.version_info[0] < 3 \
-                else self._classifier = pickle.load(f, encoding='latin1')
+        self._logger.info(sys.version_info)
 
-            if self._verbose:
-                self._logger.debug("Un-pickled model: {}".format(self._classifier))
-            self._logger.debug("Model loaded successfully!")
+        self._logger.info("Model is loading, wid: {}, path: {}".format(self.get_wid(), model_path))
+        self._logger.info("params: {}".format(pprint.pformat(self._params)))
+        model = None
+        try:
+            with open(model_path, "rb") as f:
+                self._model_loading_error = None
+                model = pickle.load(f) if sys.version_info[0] < 3 \
+                    else pickle.load(f, encoding='latin1')
+
+                if self._verbose:
+                    self._logger.debug("Un-pickled model: {}".format(self._model))
+                self._logger.debug("Model loaded successfully!")
+
+        except Exception as e:
+            self._logger.error("Error loading model: {}".format(e))
+
+            # Not sure we want to throw exception only to move to a non model mode
+            if self._params.get("ignore-incompatible-model", True):
+                self._logger.info("New model could not be loaded, due to error: {}".format(e))
+                if self._model is None:
+                    self._model_loading_error = str(e)
+            else:
+                raise Exception("Error loading model: {}".format(e))
+
+        # This line should be reached only if
+        #  a) model loaded successfully
+        #  b) model loading failed but it can be ignored
+        if model is not None:
+            self._model = model
+
+    def _empty_predict(self):
+        model_loaded = True if self._model else False
+        result_json = {
+            "message": "got empty predict",
+            "model_loaded": model_loaded,
+            "sample_keyword": SklearnRESTfulServing.JSON_KEY_NAME,
+            "python": "{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]),
+            "numpy": np.version.version,
+            "sklearn": sklearn.__version__,
+            "model_class": str(type(self._model))
+        }
+
+        if model_loaded is False and self._model_loading_error:
+            result_json["model_load_error"] = self._model_loading_error
+        if self._model:
+            if hasattr(self._model, "n_features_"):
+                result_json["n_features"] = self._model.n_features_
+
+        return result_json
 
     @FlaskRoute('/predict')
     def predict(self, url_params, form_params):
-        if SklearnRESTfulServing.JSON_KEY_NAME not in form_params:
+
+        if len(form_params) == 0:
+            return 200, self._empty_predict()
+
+        elif not self._model:
+            if self._model_loading_error:
+                return_json = {"error": "Failed loading model: {}".format(self._model_loading_error)}
+            else:
+                return_json = {"error": "Model not loaded yet - please set a model"}
+            return 404, return_json
+
+        elif SklearnRESTfulServing.JSON_KEY_NAME not in form_params:
             msg = "Unexpected json format for prediction! Missing '{}' key in: {}" \
                 .format(SklearnRESTfulServing.JSON_KEY_NAME, form_params)
             self._logger.error(msg)
-            raise Exception(msg)
-
-        if self._verbose:
-            self._logger.debug("predict, url_params: {}, form_params: {}".format(url_params, form_params))
-
-        if not self._classifier:
-            return (404, {"error": "Model not loaded yet!"})
+            error_json = {"error": msg}
+            return 404, error_json
         else:
-            if self._verbose:
-                self._logger.debug("type<form_params>: {}\n{}".format(type(form_params), form_params))
+            try:
                 two_dim_array = np.array([form_params[SklearnRESTfulServing.JSON_KEY_NAME]])
-                self._logger.debug("type(two_dim_array): {}\n{}".format(type(two_dim_array), two_dim_array))
-                prediction = self._classifier.predict(two_dim_array)
-                self._logger.debug("prediction: {}, type: {}".format(prediction[0], type(prediction[0])))
-            else:
-                two_dim_array = np.array([form_params[SklearnRESTfulServing.JSON_KEY_NAME]])
-                prediction = self._classifier.predict(two_dim_array)
-
-            return (200, {"prediction": prediction[0]})
+                prediction = self._model.predict(two_dim_array)
+                if self._verbose:
+                    self._logger.debug("predict, url_params: {}, form_params: {}".format(url_params, form_params))
+                    self._logger.debug("type<form_params>: {}\n{}".format(type(form_params), form_params))
+                    self._logger.debug("type(two_dim_array): {}\n{}".format(type(two_dim_array), two_dim_array))
+                    self._logger.debug("prediction: {}, type: {}".format(prediction[0], type(prediction[0])))
+                return 200, {"prediction": prediction[0]}
+            except Exception as e:
+                error_json = {"error": "Error performing prediction: {}".format(e)}
+                return 404, error_json
 
 
 if __name__ == '__main__':
@@ -62,6 +117,9 @@ if __name__ == '__main__':
     parser.add_argument("input_model", help="Path of input model to create")
     parser.add_argument("--log_level", choices=log_levels.keys(), default="info", help="Logging level")
     args = parser.parse_args()
+
+    if not os.path.exists(args.input_model):
+        raise Exception("Model file {} does not exists".format(args.input_model))
 
     logging.basicConfig(format='%(asctime)-15s %(levelname)s [%(module)s:%(lineno)d]:  %(message)s')
     logging.getLogger('parallelm').setLevel(log_levels[args.log_level])

--- a/reflex-algos/components/RestModelServing/restful_sklearn_serving/sklearn_restful_serving.py
+++ b/reflex-algos/components/RestModelServing/restful_sklearn_serving/sklearn_restful_serving.py
@@ -1,10 +1,11 @@
 import logging
 import numpy as np
-import sklearn
-import pickle
-import sys
-import pprint
 import os
+import pickle
+import pprint
+import sklearn
+import sys
+import warnings
 
 from parallelm.components.restful.flask_route import FlaskRoute
 from parallelm.components.restful_component import RESTfulComponent
@@ -20,32 +21,44 @@ class SklearnRESTfulServing(RESTfulComponent):
         self._params = {}
         self._verbose = self._logger.isEnabledFor(logging.DEBUG)
 
+        self.info_json = {
+            "sample_keyword": SklearnRESTfulServing.JSON_KEY_NAME,
+            "python": "{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]),
+            "numpy": np.version.version,
+            "sklearn": sklearn.__version__,
+        }
+
     def load_model_callback(self, model_path, stream, version):
         self._logger.info(sys.version_info)
 
         self._logger.info("Model is loading, wid: {}, path: {}".format(self.get_wid(), model_path))
         self._logger.info("params: {}".format(pprint.pformat(self._params)))
         model = None
-        try:
-            with open(model_path, "rb") as f:
-                self._model_loading_error = None
-                model = pickle.load(f) if sys.version_info[0] < 3 \
-                    else pickle.load(f, encoding='latin1')
 
-                if self._verbose:
-                    self._logger.debug("Un-pickled model: {}".format(self._model))
-                self._logger.debug("Model loaded successfully!")
+        with warnings.catch_warnings(record=True) as warns:
+            try:
+                with open(model_path, "rb") as f:
+                    self._model_loading_error = None
+                    model = pickle.load(f) if sys.version_info[0] < 3 \
+                        else pickle.load(f, encoding='latin1')
 
-        except Exception as e:
-            self._logger.error("Error loading model: {}".format(e))
+                    if self._verbose:
+                        self._logger.debug("Un-pickled model: {}".format(self._model))
+                    self._logger.debug("Model loaded successfully!")
 
-            # Not sure we want to throw exception only to move to a non model mode
-            if self._params.get("ignore-incompatible-model", True):
-                self._logger.info("New model could not be loaded, due to error: {}".format(e))
-                if self._model is None:
-                    self._model_loading_error = str(e)
-            else:
-                raise Exception("Error loading model: {}".format(e))
+            except Exception as e:
+                warn_str = ""
+                if len(warns) > 0:
+                    warn_str = "{}".format(warns[-1].message)
+                self._logger.error("Model loading warning: {}; Model loading error: {}".format(warn_str, e))
+
+                # Not sure we want to throw exception only to move to a non model mode
+                if self._params.get("ignore-incompatible-model", True):
+                    self._logger.info("New model could not be loaded, due to error: {}".format(e))
+                    if self._model is None:
+                        self._model_loading_error = "Model loading warning: {}; Model loading error: {}".format(warn_str, str(e))
+                    else:
+                        raise Exception("Model loading warning: {}; Model loading error: {}".format(warn_str, e))
 
         # This line should be reached only if
         #  a) model loaded successfully
@@ -58,12 +71,9 @@ class SklearnRESTfulServing(RESTfulComponent):
         result_json = {
             "message": "got empty predict",
             "model_loaded": model_loaded,
-            "sample_keyword": SklearnRESTfulServing.JSON_KEY_NAME,
-            "python": "{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]),
-            "numpy": np.version.version,
-            "sklearn": sklearn.__version__,
             "model_class": str(type(self._model))
         }
+        result_json.update(self.info_json)
 
         if model_loaded is False and self._model_loading_error:
             result_json["model_load_error"] = self._model_loading_error
@@ -84,6 +94,7 @@ class SklearnRESTfulServing(RESTfulComponent):
                 return_json = {"error": "Failed loading model: {}".format(self._model_loading_error)}
             else:
                 return_json = {"error": "Model not loaded yet - please set a model"}
+            return_json.update(self.info_json)
             return 404, return_json
 
         elif SklearnRESTfulServing.JSON_KEY_NAME not in form_params:
@@ -91,6 +102,7 @@ class SklearnRESTfulServing(RESTfulComponent):
                 .format(SklearnRESTfulServing.JSON_KEY_NAME, form_params)
             self._logger.error(msg)
             error_json = {"error": msg}
+            error_json.update(self.info_json)
             return 404, error_json
         else:
             try:
@@ -104,6 +116,7 @@ class SklearnRESTfulServing(RESTfulComponent):
                 return 200, {"prediction": prediction[0]}
             except Exception as e:
                 error_json = {"error": "Error performing prediction: {}".format(e)}
+                error_json.update(self.info_json)
                 return 404, error_json
 
 


### PR DESCRIPTION
Error response examples:
If trying to load model pickled with Py3:
{
    "error": "Failed loading model: Model loading warning: ; Model loading error: unsupported pickle protocol: 3",
    "numpy": "1.12.0",
    "python": "2.7.15",
    "sample_keyword": "prediction_vector",
    "sklearn": "0.18.1"
}


If trying to load a model, pickelde with sklearn < 0.18
{
    "error": "Failed loading model: Model loading warning: Trying to unpickle estimator DecisionTreeClassifier from version pre-0.18 when using version 0.18.1. This might lead to breaking code or invalid results. Use at your own risk.; Model loading error: 'module' object has no attribute 'ClassificationCriterion'",
    "numpy": "1.12.0",
    "python": "2.7.15",
    "sample_keyword": "prediction_vector",
    "sklearn": "0.18.1"
}
