### PR TITLE
[REF-5767] mcenter-cli: fix broken mcenter cli.

### DIFF
--- a/reflex-common/reflex-common/src/main/python/mcenter_cli/parallelm/mcenter_cli/main.py
+++ b/reflex-common/reflex-common/src/main/python/mcenter_cli/parallelm/mcenter_cli/main.py
@@ -107,7 +107,7 @@ class MCenterCli(object):
             print("Downloading mlapp: {} to {}".format(args.name, args.appdir))
             DirectoryFromMLAppBuilder(mclient, args.name, args.appdir).build()
 
-        parser = self._register_command('mlapp-download', help='download MLApp to a directory')
+        parser = self._register_command('mlapp-download', help='download MLApp to a directory', action=_mlapp_download)
         parser.add_argument('name', action='store', help='name of MLApp to download')
         parser.add_argument('appdir', action='store', help='directory to use for saving the MLApp to')
 

--- a/reflex-common/reflex-common/src/main/python/mcenter_cli/parallelm/mlapp_directory/directory_from_mlapp_builder.py
+++ b/reflex-common/reflex-common/src/main/python/mcenter_cli/parallelm/mlapp_directory/directory_from_mlapp_builder.py
@@ -87,7 +87,7 @@ class DirectoryFromMLAppBuilder:
                 node_info[MLAppKeywords.NODE_PARENT] = [node_info[MLAppKeywords.NODE_PARENT]]
 
     def _init_mlapp_info(self):
-        self._mlapp_info[MLAppKeywords.VERSION] = MLAppVersions.V1
+        self._mlapp_info[MLAppKeywords.VERSION] = MLAppVersions.V2
         self._mlapp_info[MLAppKeywords.NAME] = self._mlapp_name
         self._copy_key_val(self._mlapp_info, self._profile_info,
                            MLAppKeywords.MODEL_POLICY, MLAppProfileKeywords.MODEL_POLICY)


### PR DESCRIPTION
o Verson was switched to v1 instead of v2 (moved back to v2)
o Missing action method for download support