### PR TITLE
[REF-5742] rest stat: mlops rest model posting stats/event using REST

### DIFF
--- a/mlops/parallelm/mlops/channels/mlops_python_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_python_channel.py
@@ -15,14 +15,15 @@ from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats.single_value import SingleValue
 from parallelm.mlops.stats_category import StatCategory
 from parallelm.protobuf.ReflexEvent_pb2 import ReflexEvent
+from google.protobuf.json_format import MessageToJson
 
 
 class MLOpsPythonChannel(MLOpsChannel):
-    def __init__(self):
+    def __init__(self, rest_helper, pipeline_inst_id):
         logging.basicConfig()
         self._logger = logging.getLogger(__name__)
-        self._socket = None
-        self._init_events_client()
+        self._rest_helper = rest_helper
+        self._pipeline_inst_id = pipeline_inst_id
 
     def get_logger(self, name):
         pass
@@ -81,59 +82,26 @@ class MLOpsPythonChannel(MLOpsChannel):
             raise MLOpsException("stat_class: {} not supported yet".format(category))
 
     def stat_object(self, mlops_stat, reflex_event_message_type=ReflexEvent.StatsMessage):
-        evt = ReflexEvent()
-        evt.eventType = reflex_event_message_type
-
         stat_str = str(mlops_stat.to_semi_json()).encode("utf-8")
-        evt.data = stat_str
 
         self._logger.debug("sending: {}".format(stat_str))
-        self._write_delimited_to(evt)
-
-    def _init_events_client(self):
-        if MLOpsEnvConstants.MLOPS_ML_OBJECT_SERVER_HOST not in os.environ:
-            self._logger.info("Missing env var for ml-object (events) server host! Skipping initialization!")
-            return
-
-        if MLOpsEnvConstants.MLOPS_ML_OBJECT_SERVER_PORT not in os.environ:
-            self._logger.info("Missing env var for ml-object (events) server port! Skipping initialization!")
-            return
-
-        server_host = os.environ[MLOpsEnvConstants.MLOPS_ML_OBJECT_SERVER_HOST]
-        server_port = int(os.environ[MLOpsEnvConstants.MLOPS_ML_OBJECT_SERVER_PORT])
-        self._logger.info("Got ml-object (events) server url: {}:{}".format(server_host, server_port))
-
         try:
-            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self._socket.connect((server_host, server_port))
-        except socket.error as e:
-            msg = "Error connecting to server {}:{}".format(server_host, server_port)
-            self._logger.error(msg)
-            self._sock_cleanup_and_raise(e, msg)
-
-        self._logger.info("Done init event client")
+            self._rest_helper.post_stat(self._pipeline_inst_id, stat_str)
+        except Exception as e:
+            self._logger.error("Fail to post stat - " + str(e))
+            pass
 
     def table(self):
         raise MLOpsException("Not implemented")
 
     def event(self, event):
-        if self._socket:
-            self._write_delimited_to(event)
+        stat_str = str(MessageToJson(event)).encode("utf-8")
 
-    def _write_delimited_to(self, event):
-        serialized_message = event.SerializeToString()
-        delimiter = encoder._VarintBytes(len(serialized_message))
-        if self._socket:
-            try:
-                self._socket.sendall(delimiter + serialized_message)
-            except socket.error as e:
-                self._sock_cleanup_and_raise(e)
-
-    def _sock_cleanup_and_raise(self, ex, msg=""):
-        if self._socket:
-            self._socket.close()
-            self._socket = None
-        raise MLOpsException(str(ex) + msg)
+        self._logger.debug("sending: {}".format(stat_str))
+        try:
+            self._rest_helper.post_event(self._pipeline_inst_id, stat_str)
+        except Exception as e:
+            print("Fail to post event - " + str(e))
 
     def feature_importance(self, feature_importance_vector=None, feature_names=None, model=None, df=None):
 

--- a/mlops/parallelm/mlops/mlops.py
+++ b/mlops/parallelm/mlops/mlops.py
@@ -131,13 +131,15 @@ class MLOps(object):
         elif self._config.mlops_mode == MLOpsMode.ATTACH:
             # For now, support only python when attaching to an ION
             from parallelm.mlops.channels.mlops_python_channel import MLOpsPythonChannel
-            self._output_channel = MLOpsPythonChannel()
+            self._output_channel = MLOpsPythonChannel(self._mlops_ctx.rest_helper(),
+                                                      self._mlops_ctx.current_node().pipeline_instance_id)
         elif self._config.mlops_mode == MLOpsMode.AGENT:
             # In agent mode if the context is None, we use the python channel. Otherwise, use the pyspark channel.
             if ctx is None:
                 self._logger.info("output_channel = python")
                 from parallelm.mlops.channels.mlops_python_channel import MLOpsPythonChannel
-                self._output_channel = MLOpsPythonChannel()
+                self._output_channel = MLOpsPythonChannel(self._mlops_ctx.rest_helper(),
+                                                          self._mlops_ctx.current_node().pipeline_instance_id)
             else:
                 self._logger.info("output_channel = pyspark")
                 from parallelm.mlops.channels.mlops_pyspark_channel import MLOpsPySparkChannel
@@ -200,10 +202,10 @@ class MLOps(object):
         if self._config.mlops_mode == MLOpsMode.STAND_ALONE and connect_mlops is True:
             raise MLOpsException("Detected standalone mode with connect_mlops option == True")
 
-        self._init_output_channel(ctx)
         if self._mlops_ctx is None:
             self._mlops_ctx = MLOpsCtx(config=self._config, mode=self._config.mlops_mode)
 
+        self._init_output_channel(ctx)
         self._event_broker = EventBroker(self._mlops_ctx, self._output_channel)
         self._stats_helper = StatsHelper(self._output_channel)
         self._model_helper = ModelHelper(self._mlops_ctx.rest_helper(), self._mlops_ctx.ion(), self._stats_helper)
@@ -383,7 +385,7 @@ class MLOps(object):
         :raises: MLOpsException
         """
         self._verify_mlops_is_ready()
-        self._stats_helper.set_stat(name, data, None, category, timestamp)
+        self._stats_helper.set_stat(name, data, None, category, timestamp, self._pipeline_inst_id())
 
     def set_kpi(self, name, data, timestamp=None, units=None):
         """

--- a/mlops/parallelm/mlops/mlops_rest_connected.py
+++ b/mlops/parallelm/mlops/mlops_rest_connected.py
@@ -3,8 +3,10 @@ Implementation of REST client interfaces when in connected or attached mode.
 """
 try:  # python3
     from urllib.parse import urlencode
+    from urllib.parse import quote as encoder
 except ImportError:  # python2
     from urllib import urlencode
+    from urllib import quote as encoder
 
 import requests
 import json
@@ -266,6 +268,51 @@ class MlOpsRestConnected(MlOpsRestHelper):
                         workflowNodeId=workflow_node_id, agentId=agent_id, pipelineId=pipeline_id, ionId=ion_id,
                         start=start_time, end=end_time)
         return self._get_url_request_response_as_json(url)
+
+    def post_event(self, pipeline_inst_id, event):
+        """
+        Post event using protobuf format
+        :param pipeline_inst_id:  pipeline instance identifier
+        :param event:             ReflexEvent based on protobuf
+        :return:                  Json response from agent
+        """
+        url = build_url(self._mlops_server, self._mlops_port, MLOpsRestHandles.EVENTS, pipeline_inst_id)
+        try:
+            payload = encoder(event)
+            headers = {"Content-Type": "application/json;charset=UTF-8"}
+            r = requests.post(url, data=payload, headers=headers, cookies=self._return_cookie())
+            if r.ok:
+                return r.json()
+            else:
+                raise MLOpsException('Call {} with payload {} failed text:[{}]'.format(url, event, r.text))
+        except requests.exceptions.ConnectionError as e:
+            self._error(e)
+            raise MLOpsException("Connection to MLOps agent [{}:{}] refused".format(self._mlops_server, self._mlops_port))
+        except Exception as e:
+            raise MLOpsException('Call ' + str(url) + ' failed with error ' + str(e))
+
+    def post_stat(self, pipeline_inst_id, stat):
+        """
+        Post stat to agent using json formatting
+        :param pipeline_inst_id: pipeline instance identifier
+        :param stat:             stat in json format
+        :return:                 Json response from agent
+        """
+        url = build_url(self._mlops_server, self._mlops_port, MLOpsRestHandles.STATS,
+                        pipeline_inst_id, statType="accumulator")
+        try:
+            payload = encoder(stat)
+            headers = {"Content-Type": "application/json;charset=UTF-8"}
+            r = requests.post(url, data=payload, headers=headers, cookies=self._return_cookie())
+            if r.ok:
+                return r.json()
+            else:
+                raise MLOpsException('Call {} with payload {} failed text:[{}]'.format(url, stat, r.text))
+        except requests.exceptions.ConnectionError as e:
+            self._error(e)
+            raise MLOpsException("Connection to MLOps agent [{}:{}] refused".format(self._mlops_server, self._mlops_port))
+        except Exception as e:
+            raise MLOpsException('Call ' + str(url) + ' failed with error ' + str(e))
 
     def url_get_model_stats(self, model_id):
         return build_url(self._mlops_server, self._mlops_port, self._prefix, MLOpsRestHandles.MODEL_STATS, modelId=model_id)

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -33,7 +33,7 @@ class StatsHelper(BaseObj):
             raise MLOpsException("Type : {} is not yet supported by {}".
                                  format(type(data).__name__, Constants.OFFICIAL_NAME))
 
-    def set_stat(self, name, data, model_id, category, timestamp):
+    def set_stat(self, name, data, model_id, category, timestamp, pipeline_inst_id):
         # If it supports the stat_object API, return the object.
         if isinstance(name, MLOpsStatGetter):
             self._output_channel.stat_object(name.get_mlops_stat(model_id))

--- a/reflex-algos/pom.xml
+++ b/reflex-algos/pom.xml
@@ -192,6 +192,12 @@
             <version>3.3.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
disable socket connection from mlops to ECO when posting stats/events
Stas are posted to StatPostHandler at agent
http://<addres>:4567/stats/:pipelineInstanceId
    Format is the same as before json format
{"name":"","valued":"<nested json as string>"}
    {"name": "Validation Actual Label Distribution",
     "value": "{
            \"name\":\"USER_DEFINED\",
            \"timestamp\": 1552222105149544960,
            \"graphType\": \"BARGRAPH\",
            \"mode\": \"INSTANT\",
            \"type\":\"General\",
            \"data\": \"{\\\"Validation Actual Label Distribution\\\":
[{\\\"0\\\": 174}, {\\\"1\\\": 156}]}\",
            \"modelId\": null}"
    }

    Events are postes to EventPostHandler at agent
http://<address>:4567/events/:pipelineInstanceId
    Format is Json generated by protobuf
    {
      "eventLabel": "[Training] PSI Violation From Training Node",
      "eventType": "GenericHealthAlert",
      "data":"<byte array encoded>",
      "isAlert": true
    }

    test done:
    Run MLaps (SparkBatch, generic, python container) and verify:
    - Events are received in EventsPostHandler
    - Stats are generated and recv in StatsPostHandler
    - Health are transfer correctly
    - L2/L3 view is generated correctly