### PR TITLE
[REF-5721] ComponentUpload: Send the full exception message

### DIFF
--- a/reflex-algos/src/main/scala/org/mlpiper/infrastructure/factory/ComponentJSONSignatureParser.scala
+++ b/reflex-algos/src/main/scala/org/mlpiper/infrastructure/factory/ComponentJSONSignatureParser.scala
@@ -133,8 +133,9 @@ object ComponentJSONSignatureParser {
     } catch {
       case e : Throwable =>
         val msg = s"Invalid component's description file json format!"
-        logger.error(s"$msg, exception: ${e.getMessage}")
-        throw new Exception(msg)
+        val error_string = s"$msg, exception: ${e.getMessage}"
+        logger.error(error_string)
+        throw new Exception(error_string)
     }
   }
 


### PR DESCRIPTION
Useful information gets lost (eg the actual error is lost and only a generic message is printed)