### PR TITLE
[REF-5919 ]handle exit() call in pipeline exit status

### DIFF
--- a/mlcomp/tests/test_mlcomp_python.py
+++ b/mlcomp/tests/test_mlcomp_python.py
@@ -7,7 +7,7 @@ import json
 from parallelm.pipeline.components_desc import ComponentsDesc
 from parallelm.ml_engine.python_engine import PythonEngine
 from parallelm.pipeline.dag import Dag
-from parallelm.pipeline.executor import Executor
+from parallelm.pipeline.executor import Executor, ExecutorException
 from parallelm.pipeline.executor_config import ExecutorConfig
 
 import parallelm.pipeline.json_fields as json_fields
@@ -127,6 +127,57 @@ class TestPythonEngine:
         os.environ.setdefault("TEST_VAR", "test-value")
         os.environ.setdefault("TEST_VAR2", "non test value")
         Executor(config).go()
+
+    # @pytest.mark.skip(reason="skipping this test for now - debugging")
+    def test_execute_python_stand_alone_with_exit_0(self):
+        pipeline = {
+            "name": "stand_alone_test",
+            "engineType": "Generic",
+
+            "pipe": [
+                {
+                    "name": "Hello",
+                    "id": 1,
+                    "type": "test-argument-from-env-var",
+                    "parents": [],
+                    "arguments": {
+                        "arg1": "test-exit-0",
+                        "fromEnvVar2": "test-value2",
+                    },
+                }
+            ]
+        }
+        self._fix_pipeline(pipeline, None)
+        config = self._get_executor_config(pipeline)
+        Executor(config).go()
+
+    # @pytest.mark.skip(reason="skipping this test for now - debugging")
+    def test_execute_python_stand_alone_with_exit_1(self):
+        pipeline = {
+            "name": "stand_alone_test",
+            "engineType": "Generic",
+
+            "pipe": [
+                {
+                    "name": "Hello",
+                    "id": 1,
+                    "type": "test-argument-from-env-var",
+                    "parents": [],
+                    "arguments": {
+                        "arg1": "test-exit-1",
+                        "fromEnvVar2": "test-value2",
+                    },
+                }
+            ]
+        }
+        self._fix_pipeline(pipeline, None)
+        config = self._get_executor_config(pipeline)
+        passed = 0
+        try:
+            Executor(config).go()
+        except ExecutorException as e:
+            passed = str(e).startswith("Pipeline called exit(), with code: 1")
+        assert(passed)
 
     # @pytest.mark.skip(reason="skipping this test for now - debugging")
     def test_execute_python_connected(self, caplog):

--- a/reflex-algos/components/Python/test-argument-from-env-var/main.py
+++ b/reflex-algos/components/Python/test-argument-from-env-var/main.py
@@ -22,6 +22,11 @@ def main():
     expected_str_value = format(options.arg1)
     actual_value = format(options.fromEnvVar)
 
+    if expected_str_value == "test-exit-0":
+        exit(0)
+    if expected_str_value == "test-exit-1":
+        exit(1)
+
     print("arg1: {}".format(options.arg1))
     print("fromEnvVar: {}".format(options.fromEnvVar))
 


### PR DESCRIPTION
if pipeline exits with status 0, exit from executor with status 0.
otherwise throw exception

More info about error messages:
When run with mlpiper (no deputy), stack trace will look like this:
```End of go
Traceback (most recent call last):
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/pipeline/executor.py", line 124, in go
    dag.run_connected_pipeline(system_conf, self._ml_engine)
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/pipeline/dag.py", line 98, in run_connected_pipeline
    data_objs = dag_node.component_runner.run(parent_data_objs)
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/pipeline/component_runner/python_connected_component_runner.py", line 15, in run
    data_objs = self._dag_node.main_cls().materialize(parent_data_objs)
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/components/connectable_component.py", line 11, in materialize
    return self._materialize(parent_data_objs, self._ml_engine.user_data)
  File "/private/tmp/con/mcenter_components-0.1-py2.7.egg/parallelm/code_components/string-source/string_source.py", line 11, in _materialize
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/_sitebuiltins.py", line 26, in __call__
    raise SystemExit(code)
SystemExit: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/bin/mlpiper", line 5, in <module>
    main(bin_dir=os.path.dirname(__file__))
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/mlpiper/main.py", line 155, in main
    ml_piper.run_deployment()
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/mlpiper/mlpiper.py", line 275, in run_deployment
    pipeline_runner.go()
  File "/Users/yakov/src/reflex/sub/mlpiper/mlcomp/parallelm/pipeline/executor.py", line 130, in go
    raise Exception(log_message)
Exception: pipeline called exit(1)
```
Component, which called exit() can be easily seen.


But in mcenter detailed stacktrace is suppressed  by deputy.
```
========= Error from code ==========
 - to server
19/03/18 16:56:09 INFO agent.PipelineRunner: [test env var 2] Sending eco msg : error:Traceback (most recent call last):
  File "/tmp/deputy/_artifact_dir_6076696987589907507/deputy-py2.egg/parallelm/deputy/deputy.py", line 43, in run
    pipeline_runner.go()
  File "/tmp/deputy/_artifact_dir_6076696987589907507/mlcomp-py2.egg/parallelm/pipeline/executor.py", line 130, in go
    raise Exception(log_message)
Exception: pipeline called exit(1)
========= Error from code ==========
```

My patch can be moved on the lower level, separately into single/connected runners. 
Or, maybe, we can catch exit in single/connected runner, and call exit() again with updated message.