### PR TITLE
[REF-5940] use non-interactive backend for matplotlib in tests

### DIFF
--- a/mlops/tests/test_time_capture.py
+++ b/mlops/tests/test_time_capture.py
@@ -4,6 +4,14 @@ import os
 import shutil
 import tarfile
 
+# force to use not-interactive backend (when there is no real display)
+# remove this is if you want to show real window
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+except:
+    print("matplotlib package is not installed")
+
 from time_capture_test_helper import TimeCapture1
 from parallelm.mlops import mlops as pm
 from parallelm.mlops.time_capture.plot_functions import PlotFunctions


### PR DESCRIPTION
This test started to fail on newly installed Ubuntu nodes, where
matplotlib is installed(sometimes),but no real interatictive backend provided.

The fix is to use non-interactive (output to image) backend.
use() call defines behavior for all later matplotlib imports.

Our PlotFunctions class also handles import exception,
that's why mlops tests are no failing in docker build, where matplotlib
is not installed. :))))) so test just does nothing :)