### PR TITLE
[REF-5995] mlcomp unit-tests fail following the fix in [REF-5975]

### DIFF
--- a/mlcomp/parallelm/__init__.py
+++ b/mlcomp/parallelm/__init__.py
@@ -1,1 +1,2 @@
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)

--- a/mlops/parallelm/__init__.py
+++ b/mlops/parallelm/__init__.py
@@ -1,1 +1,2 @@
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Apparently, using namespace packages is very delicate and must be used with caution