### PR TITLE
Do mvn clean by default when compiling common/algos with dockers

### DIFF
--- a/reflex-algos/build/docker-entrypoint.sh
+++ b/reflex-algos/build/docker-entrypoint.sh
@@ -8,7 +8,7 @@ adduser -u $HOST_UID -g $HOST_GID -d $HOME -M $HOST_USERNAME
 ln -s /tmp/m2 ${HOME}/.m2
 
 # Run the build
-DEFAULT_BUILD="mvn install -Dmaven.javadoc.skip=true -P scala-2.11 "
+DEFAULT_BUILD="mvn clean install -Dmaven.javadoc.skip=true"
 MVN_ARGS=""
 
 if [ ! -z "$1" ] && [ "$1" == "-DskipTests" ]; then

--- a/reflex-common/build/docker-entrypoint.sh
+++ b/reflex-common/build/docker-entrypoint.sh
@@ -8,7 +8,7 @@ adduser -u $HOST_UID -g $HOST_GID -d $HOME -M $HOST_USERNAME
 ln -s /tmp/m2 ${HOME}/.m2
 
 # Run the build
-DEFAULT_BUILD="mvn install -Dmaven.javadoc.skip=true "
+DEFAULT_BUILD="mvn clean install -Dmaven.javadoc.skip=true "
 MVN_ARGS=""
 if [ ! -z "$1" ] && [ "$1" == "-DskipTests" ]; then
    MVN_ARGS="-DskipTests"


### PR DESCRIPTION
Not cleaning leads to multiple mlops/mlcomp eggs are created in target folder.