### PR TITLE
[REF-5957] implement Exceptions handler decorator

### DIFF
--- a/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
@@ -128,10 +128,7 @@ class MLOpsPySparkChannel(MLOpsChannel):
         if self._rest_helper:
             stat_str = str(MessageToJson(event)).encode("utf-8")
             self._logger.debug("sending: {}".format(stat_str))
-            try:
-                self._rest_helper.post_event(self._pipeline_inst_id, stat_str)
-            except Exception as e:
-                print("Fail to post event - " + str(e))
+            self._rest_helper.post_event(self._pipeline_inst_id, stat_str)
 
     def feature_importance(self, feature_importance_vector=None, feature_names=None, model=None, df=None):
 

--- a/mlops/parallelm/mlops/channels/mlops_python_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_python_channel.py
@@ -92,12 +92,8 @@ class MLOpsPythonChannel(MLOpsChannel):
 
     def event(self, event):
         stat_str = str(MessageToJson(event)).encode("utf-8")
-
         self._logger.debug("sending: {}".format(stat_str))
-        try:
-            self._rest_helper.post_event(self._pipeline_inst_id, stat_str)
-        except Exception as e:
-            print("Fail to post event - " + str(e))
+        self._rest_helper.post_event(self._pipeline_inst_id, stat_str)
 
     def feature_importance(self, feature_importance_vector=None, feature_names=None, model=None, df=None):
 

--- a/mlops/parallelm/mlops/channels/mlops_python_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_python_channel.py
@@ -1,16 +1,12 @@
 import logging
-import os
-import socket
 
 import numpy as np
 import pandas as pd
-from google.protobuf.internal import encoder
 from numpy.core.multiarray import ndarray
 
 from parallelm.mlops.channels.mlops_channel import MLOpsChannel
 from parallelm.mlops.channels.python_channel_health import PythonChannelHealth
 from parallelm.mlops.constants import Constants
-from parallelm.mlops.mlops_env_constants import MLOpsEnvConstants
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats.single_value import SingleValue
 from parallelm.mlops.stats_category import StatCategory

--- a/mlops/parallelm/mlops/channels/mlops_python_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_python_channel.py
@@ -79,13 +79,8 @@ class MLOpsPythonChannel(MLOpsChannel):
 
     def stat_object(self, mlops_stat, reflex_event_message_type=ReflexEvent.StatsMessage):
         stat_str = str(mlops_stat.to_semi_json()).encode("utf-8")
-
         self._logger.debug("sending: {}".format(stat_str))
-        try:
-            self._rest_helper.post_stat(self._pipeline_inst_id, stat_str)
-        except Exception as e:
-            self._logger.error("Fail to post stat - " + str(e))
-            pass
+        self._rest_helper.post_stat(self._pipeline_inst_id, stat_str)
 
     def table(self):
         raise MLOpsException("Not implemented")

--- a/mlops/parallelm/mlops/mlops.py
+++ b/mlops/parallelm/mlops/mlops.py
@@ -30,7 +30,7 @@ from parallelm.mlops.events.system_alert import SystemAlert
 from parallelm.mlops.ion.ion import Agent
 from parallelm.mlops.logger_factory import logger_factory
 from parallelm.mlops.mlops_ctx import MLOpsCtx
-from parallelm.mlops.mlops_exception import MLOpsException, SuppressException
+from parallelm.mlops.mlops_exception import MLOpsException, MLOpsConnectionException, SuppressException
 from parallelm.mlops.models.model import Model
 from parallelm.mlops.models.model import ModelFormat
 from parallelm.mlops.models.model_filter import ModelFilter
@@ -786,6 +786,7 @@ class MLOps(object):
         self.event(CanaryAlert(title, is_healthy, score, threshold))
         return self
 
+    @SuppressException([MLOpsConnectionException])
     def event(self, event_obj):
         """
         Generate an event which is sent to MLOps.
@@ -802,6 +803,7 @@ class MLOps(object):
         self._event_broker.send_event(event_obj)
         return self
 
+    @SuppressException([MLOpsConnectionException])
     def set_event(self, name, type=None, data=None, is_alert=False, timestamp=None):
         """
         Generate an event which is sent to MLOps.

--- a/mlops/parallelm/mlops/mlops.py
+++ b/mlops/parallelm/mlops/mlops.py
@@ -384,6 +384,7 @@ class MLOps(object):
         """
         return self._curr_model
 
+    @SuppressException([MLOpsConnectionException])
     def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None):
         """
         Report this statistic.

--- a/mlops/parallelm/mlops/mlops.py
+++ b/mlops/parallelm/mlops/mlops.py
@@ -30,8 +30,7 @@ from parallelm.mlops.events.system_alert import SystemAlert
 from parallelm.mlops.ion.ion import Agent
 from parallelm.mlops.logger_factory import logger_factory
 from parallelm.mlops.mlops_ctx import MLOpsCtx
-from parallelm.mlops.mlops_exception import MLOpsException
-from parallelm.mlops.mlops_mode import MLOpsMode
+from parallelm.mlops.mlops_exception import MLOpsException, SuppressException
 from parallelm.mlops.models.model import Model
 from parallelm.mlops.models.model import ModelFormat
 from parallelm.mlops.models.model_filter import ModelFilter
@@ -242,6 +241,15 @@ class MLOps(object):
     @property
     def init_called(self):
         return self._init_called
+
+    def suppress_connection_errors(self, suppress):
+        """
+        Turn on/off connection errors suppression; suppress MLOpsConnectionException.
+        If suppression is turned on, errors are logged as warnings.
+
+        :param suppress: boolean True/False
+        """
+        SuppressException.set_suppress(suppress)
 
     @property
     def mlapp_id(self):
@@ -769,7 +777,7 @@ class MLOps(object):
         :param title: A short description that is used as the title
         :param is_healthy: whether the canary pipeline is healthy
         :param score: the canary comparison score
-        :param theshold: the canary comparison threshold
+        :param threshold: the canary comparison threshold
         :return: The current PM instance for further calls
         :raises: MLOpsException
 
@@ -909,7 +917,7 @@ class MLOps(object):
     def publish_model(self, model):
         """
         Exports Model to the PM service.
-        Model data and metada must be set using :class:`Model`
+        Model data and metadata must be set using :class:`Model`
 
         :param model: Object of type :class:`Model`
         :return: The model Id

--- a/mlops/parallelm/mlops/mlops_exception.py
+++ b/mlops/parallelm/mlops/mlops_exception.py
@@ -1,3 +1,7 @@
+import functools
+import logging
+
+
 class MLOpsException(Exception):
     """
     Exception that will be returned by the MLOps class on error
@@ -5,8 +9,77 @@ class MLOpsException(Exception):
     pass
 
 
-class MLOpsException(Exception):
-    """
-    Exception to be returned by mlops api functions on error
-    """
-    pass
+"""
+SuppressException decorator can be used to suppress Exceptions.
+
+When used without arguments, by default all the Exceptions will be suppressed.
+@SuppressException()
+method()
+
+If used with arguments:
+All exceptions inherited from GenericException will be suppressed.
+@SuppressException([GenericException])
+method()
+
+TODO: currently the only usage is to suppress ConnectionException.
+When decorator will be used to suppress several types of exceptions,
+and it will be needed to suppress A but not suppress B, include/exclude lists/APIs can be added.
+
+e.g
+@SuppressException([A, C])
+method1()
+
+@SuppressException([B])
+method2()
+
+SuppressException.set_suppress(True)  # all A, B, C will be suppressed
+SuppressException.include([A, B]) # only A, B will be suppressed
+SuppressException.exclude([B]) # only A will be suppressed
+
++ maybe add return value for suppression definition.
+"""
+    
+    
+class SuppressException(object):
+    _suppress = False
+
+    def __init__(self, exc_list=[Exception], handler=None):
+        self._logger = logging.getLogger(SuppressException.__name__)
+        self._handler = self._warn if handler is None else handler
+        self._exceptions = tuple(exc_list)
+
+    def _warn(self, e):
+        self._logger.warning("suppressed exception: {}".format(str(e)))
+
+    def __call__(self, func):
+        """
+        If there are decorator arguments, __call__() is only called
+        once, as part of the decoration process! You can only give
+        it a single argument, which is the function object.
+        """
+
+        # The meaning of decorator is that wrapper
+        # wraps decorated func, and replaces it.
+        # So when one calls func() actually wrapper() will be called.
+        # `that` is `self` from a decorated method
+        @functools.wraps(func)
+        def wrapper(that, *args, **kwargs):
+            if not self._suppress:
+                return func(that, *args, **kwargs)
+            else:
+                try:
+                    return func(that, *args, **kwargs)
+                except self._exceptions as e:
+                    self._handler(e)
+                return None
+
+        return wrapper
+
+    @classmethod
+    def set_suppress(cls, suppress):
+        """
+        Turn on/off exception suppression for methods decorated by :class:`SuppressException`
+
+        :param suppress: boolean True/False
+        """
+        cls._suppress = suppress

--- a/mlops/parallelm/mlops/mlops_exception.py
+++ b/mlops/parallelm/mlops/mlops_exception.py
@@ -9,6 +9,13 @@ class MLOpsException(Exception):
     pass
 
 
+class MLOpsConnectionException(MLOpsException):
+    """
+    Exception that will be returned by the MLOps class on connection error
+    """
+    pass
+
+
 """
 SuppressException decorator can be used to suppress Exceptions.
 

--- a/mlops/parallelm/mlops/mlops_rest_connected.py
+++ b/mlops/parallelm/mlops/mlops_rest_connected.py
@@ -305,6 +305,15 @@ class MlOpsRestConnected(MlOpsRestHelper):
         except Exception as e:
             raise MLOpsException('Call ' + str(url) + ' failed with error: ' + str(e))
 
+    def url_post_stat(self, pipeline_inst_id):
+        """
+        Create the REST request for posting stat
+        :param pipeline_inst_id:    pipeline instance identifier
+        :return:                    the URL for the REST request
+        """
+        return build_url(self._mlops_server, self._mlops_port, MLOpsRestHandles.STATS,
+                         pipeline_inst_id, statType="accumulator")
+
     def post_stat(self, pipeline_inst_id, stat):
         """
         Post stat to agent using json formatting
@@ -316,8 +325,7 @@ class MlOpsRestConnected(MlOpsRestHelper):
             self._error("Missing pipeline instance id cannot post stat")
             return
 
-        url = build_url(self._mlops_server, self._mlops_port, MLOpsRestHandles.STATS,
-                        pipeline_inst_id, statType="accumulator")
+        url = self.url_post_stat(pipeline_inst_id)
         try:
             payload = encoder(stat)
             headers = {"Content-Type": "application/json;charset=UTF-8"}
@@ -325,7 +333,7 @@ class MlOpsRestConnected(MlOpsRestHelper):
             if r.ok:
                 return r.json()
             else:
-                raise MLOpsException('Call {} with payload {} failed text:[{}]'.format(url, stat, r.text))
+                self._error('Call {} with payload {} failed: text:[{}]'.format(url, stat, r.text))
         except requests.exceptions.ConnectionError as e:
             self._error(e)
             raise MLOpsException("Connection to MLOps agent [{}:{}] refused".format(self._mlops_server, self._mlops_port))

--- a/mlops/parallelm/mlops/mlops_rest_connected.py
+++ b/mlops/parallelm/mlops/mlops_rest_connected.py
@@ -291,7 +291,7 @@ class MlOpsRestConnected(MlOpsRestHelper):
             if r.ok:
                 return r.json()
             else:
-                raise MLOpsException('Call {} with payload {} failed text:[{}]'.format(url, event, r.text))
+                self._error('Call {} with payload {} failed: text:[{}]'.format(url, event, r.text))
         except requests.exceptions.ConnectionError as e:
             self._error(e)
             raise MLOpsException("Connection to MLOps agent [{}:{}] refused".format(self._mlops_server, self._mlops_port))

--- a/mlops/parallelm/mlops/mlops_rest_connected.py
+++ b/mlops/parallelm/mlops/mlops_rest_connected.py
@@ -336,7 +336,7 @@ class MlOpsRestConnected(MlOpsRestHelper):
                 self._error('Call {} with payload {} failed: text:[{}]'.format(url, stat, r.text))
         except requests.exceptions.ConnectionError as e:
             self._error(e)
-            raise MLOpsException("Connection to MLOps agent [{}:{}] refused".format(self._mlops_server, self._mlops_port))
+            raise MLOpsConnectionException("Connection to MLOps agent [{}:{}] refused; {}".format(self._mlops_server, self._mlops_port, e))
         except Exception as e:
             raise MLOpsException('Call ' + str(url) + ' failed with error ' + str(e))
 

--- a/mlops/tests/test_mlops.py
+++ b/mlops/tests/test_mlops.py
@@ -149,6 +149,7 @@ def test_suppress_connection_errors():
         m.get(rest_helper.url_get_model_stats(ION1.MODEL_ID), json=test_model_stats)
 
         m.post(rest_helper.url_post_event(pipeline_instance_id), exc=requests.exceptions.ConnectionError)
+        m.post(rest_helper.url_post_stat(pipeline_instance_id), exc=requests.exceptions.ConnectionError)
 
         pm.init(ctx=None, mlops_mode=MLOpsMode.AGENT)
 
@@ -161,9 +162,13 @@ def test_suppress_connection_errors():
         with pytest.raises(MLOpsConnectionException):
             pm.event(event_obj)
 
+        with pytest.raises(MLOpsConnectionException):
+            pm.set_stat("stat_same", 3)
+
         pm.suppress_connection_errors(True)
         pm.set_event(name="event_name", data="123", type=EventType.System)
         pm.event(event_obj)
+        pm.set_stat("stat_same", 3)
         pm.suppress_connection_errors(False)
 
         pm.done()

--- a/mlops/tests/test_models.py
+++ b/mlops/tests/test_models.py
@@ -270,6 +270,7 @@ def test_feature_importance():
     num_significant_features = 6
     ion_instance_id = ION1.ION_INSTANCE_ID
     ion_node_id = ION1.NODE_1_ID
+    pipeline_instance_id = ION1.PIPELINE_INST_ID_1
     set_mlops_env(ion_id=ion_instance_id, ion_node_id=ion_node_id, model_id=ION1.MODEL_ID)
     rest_helper = MlOpsRestFactory().get_rest_helper(MLOpsMode.AGENT, mlops_server="localhost",
                                                      mlops_port="3456", token="")
@@ -282,6 +283,7 @@ def test_feature_importance():
         m.get(rest_helper.url_get_health_thresholds(ion_instance_id), json=test_health_info)
         m.get(rest_helper.url_get_model_stats(ION1.MODEL_ID), json=test_model_stats)
         m.get(rest_helper.url_get_uuid("model"), json={"id": "model_5906255e-0a3d-4fef-8653-8d41911264fb"})
+        m.post(rest_helper.url_post_stat(pipeline_instance_id), json={})
 
         # Test Python channel
         mlops.init(ctx=None, mlops_mode=MLOpsMode.AGENT)

--- a/mlops/tests/test_suppress_exceptions.py
+++ b/mlops/tests/test_suppress_exceptions.py
@@ -1,0 +1,93 @@
+import pytest
+
+from parallelm.mlops.mlops_exception import MLOpsException, SuppressException
+from parallelm.mlops import mlops
+
+
+class MLOpsTestException(MLOpsException):
+    pass
+
+
+exception_handler_called = False
+
+
+def exception_handler(e):
+    global exception_handler_called
+    exception_handler_called = type(e) == MLOpsTestException
+
+
+class TestApi(object):
+
+    @SuppressException()
+    def api_raise_exception(self):
+        raise Exception("raising exception")
+
+    @SuppressException([MLOpsException])
+    def api_raise_mlops_exception(self):
+        raise MLOpsException("raising MLOps exception")
+
+    @SuppressException([MLOpsTestException])
+    def api_raise_mlops_test_exception(self):
+        raise MLOpsTestException("raising MLOps test exception")
+
+    @SuppressException([MLOpsTestException])
+    def api_raise_mlops_or_test_exception(self, arg=0):
+        if arg == 0:
+            raise MLOpsException("raising MLOps exception")
+        else:
+            raise MLOpsTestException("raising MLOps test exception")
+
+    @SuppressException([MLOpsTestException], exception_handler)
+    def api_raise_mlops_test_exception2(self):
+        raise MLOpsTestException("raising MLOps test exception")
+
+
+def test_not_suppressed_exceptions():
+    ta = TestApi()
+    mlops.suppress_connection_errors(False)
+    with pytest.raises(Exception):
+        ta.api_raise_exception()
+
+    with pytest.raises(MLOpsException):
+        ta.api_raise_mlops_exception()
+
+    with pytest.raises(MLOpsTestException):
+        ta.api_raise_mlops_test_exception()
+
+    with pytest.raises(MLOpsException):
+        ta.api_raise_mlops_or_test_exception()
+
+    with pytest.raises(MLOpsTestException):
+        ta.api_raise_mlops_or_test_exception(1)
+
+    with pytest.raises(MLOpsTestException):
+        ta.api_raise_mlops_test_exception2()
+
+
+def test_suppressed_exceptions():
+
+    ta = TestApi()
+    mlops.suppress_connection_errors(True)
+
+    # Exception class is suppressed
+    ta.api_raise_exception()
+
+    # MLOpsException and MLOpsTestException are suppressed
+    ta.api_raise_mlops_exception()
+    ta.api_raise_mlops_test_exception()
+
+    # MLOpsTestException is suppressed...
+    ta.api_raise_mlops_or_test_exception(1)
+
+    # ...but not MLOpsException
+    with pytest.raises(MLOpsException):
+        ta.api_raise_mlops_or_test_exception(0)
+
+    # test MLOpsTestException is suppressed and user provided handler is called
+    ta.api_raise_mlops_test_exception2()
+    assert(exception_handler_called)
+
+    # turn suppression off
+    mlops.suppress_connection_errors(False)
+    with pytest.raises(MLOpsTestException):
+        ta.api_raise_mlops_test_exception()


### PR DESCRIPTION
This is implementation of the decorator to be used on the exiting mlops API.  
It allows to intercept exception and suppress it, without deeply changing API.

Please review it and propose improvements, actions we need besides suppress, etc
This skeleton can be already used on the existing APIs, but they should be cleaned up:
- we need to define more exception types.
- review each method, that it actually raises meaningful exception.

============
The idea is that if we have an API that throws exception,
we could easily control it: suppress exception or do some other action.

Consider we have: set_stat().
No we can add a decorator:

@SuppressException(MLOpsException)
set_stat()

Now, if set_stat() throws exception, it will be processed in decorator
function, according to the rules.