### PR TITLE
[REF-5989] decode str returned by pkg_resources.resource_string

### DIFF
--- a/mlcomp/parallelm/pipeline/components_desc.py
+++ b/mlcomp/parallelm/pipeline/components_desc.py
@@ -78,4 +78,5 @@ class ComponentsDesc(Base):
             self._logger.error(msg)
             raise MLCompException(msg)
 
-        return pkg_resources.resource_string(component_package, metadata_filename)
+        # resource_string returns binary string, so need to decode
+        return pkg_resources.resource_string(component_package, metadata_filename).decode()


### PR DESCRIPTION
pkg_resources.resource_string returns binary string, which has to be
decoded.
I don't know if it is actual failure in python 3.5 for kenshoo
But for me it fails in Py3.5

https://setuptools.readthedocs.io/en/latest/pkg_resources.html