### PR TITLE
[REF-6011] Handle object type returned from component

### DIFF
--- a/mlcomp/parallelm/pipeline/dag.py
+++ b/mlcomp/parallelm/pipeline/dag.py
@@ -112,9 +112,12 @@ class Dag(Base):
             sys.stdout.flush()
 
             runtime_in_sec = time.time() - start
-            if data_objs and type(data_objs) is not list:
-                raise MLCompException("Invalid returned data type from component! It should be a list! "
+            if data_objs is None:
+                raise MLCompException("Invalid returned data type from component! It should be a list or not None object! "
                                       "name: " + dag_node.comp_name())
+
+            if type(data_objs) is not list:
+                data_objs = [data_objs]
 
             self._component_run_footer(dag_node, data_objs, runtime_in_sec)
 


### PR DESCRIPTION
Connected component supposed to return a list, but current error
handling was allowing a None object, which can happen if user forgets to
return.

New behavior is, if user returns:
- None (or forgets to return) - exception is raised
- single object, this object is put into a list and passed to the next
component
- list is legal as before