### PR TITLE
[REF-6049] fix copying files from shared comps dir to separate comp dir

### DIFF
--- a/mlcomp/parallelm/mlpiper/component_scanner.py
+++ b/mlcomp/parallelm/mlpiper/component_scanner.py
@@ -54,11 +54,20 @@ class ComponentScanner(object):
         init_py_found = False
         for root, _, files in os.walk(comp_root):
             for f in files:
-                rltv_path = os.path.relpath(root,  comp_root)
+                rltv_path = os.path.relpath(root, comp_root)
                 filepath = os.path.join(rltv_path, f) if rltv_path != "." else f
                 if self._path_included(filepath, include_patterns, exclude_patterns):
                     if filepath == "__init__.py":
                         init_py_found = True
+
+                    # There can be several comp JSONs in one folder.
+                    # Only one, related to the current component has to be included.
+                    # (others should not be included)
+                    comp_desc_tmp = ComponentsDesc._load_comp_desc(comp_root, f)
+                    key_name = json_fields.COMPONENT_DESC_NAME_FIELD
+                    if comp_desc_tmp and comp_desc[key_name] != comp_desc_tmp[key_name]:
+                        continue
+
                     included_files.append(filepath)
 
         if not init_py_found:

--- a/mlcomp/parallelm/pipeline/components_desc.py
+++ b/mlcomp/parallelm/pipeline/components_desc.py
@@ -129,6 +129,7 @@ class ComponentsDesc(Base):
             # Try to find any valid component's description file
             comp_desc_gen = ComponentsDesc.next_comp_desc(comp_path)
             try:
+                # next() is called only once, because only one component JSON file is expected.
                 _, comp_desc = next(comp_desc_gen)
             except StopIteration:
                 comp_desc = None


### PR DESCRIPTION
When working with shared dir components,
and glob - include/exclude rules are not provided,
all the files will be copied into each component directory.

So during the run, in each dir there will be several JSON component
files, which causes unpredicted behavior.