### PR TITLE
[REF-6034] MLOps: Adding **kwargs To MLOps.set_stat

### DIFF
--- a/mlops/parallelm/mlops/channels/mlops_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_channel.py
@@ -3,8 +3,10 @@ Class representing the output channel to be used to report statistics/operations
 """
 
 import abc
-from parallelm.mlops.stats_category import StatCategory, StatsMode, StatGraphType
+
 from parallelm.mlops.stats.table import is_list_of_lists
+from parallelm.mlops.stats_category import StatCategory, StatsMode, StatGraphType
+
 
 class MLOpsChannel:
     """
@@ -17,7 +19,7 @@ class MLOpsChannel:
         pass
 
     @abc.abstractmethod
-    def stat(self, name, data, model_id, category=None, sparkml_model=None, model_stat=None):
+    def stat(self, name, data, model_id, category=None, sparkml_model=None, model_stat=None, **kwargs):
         """
         methods to submit a stat to a specific channel (pyspark/python/file etc) each channel is
         required to implement the method to support posting of statistics to that channel

--- a/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
@@ -1,18 +1,18 @@
 import json
 import os
+
 import pyspark
 import pyspark.mllib.common as ml
-import socket
-from google.protobuf.internal import encoder
+from google.protobuf.json_format import MessageToJson
+from pyspark.ml.pipeline import PipelineModel
+from pyspark.sql import DataFrame
+
 from parallelm.mlops.channels.mlops_channel import MLOpsChannel
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.data_to_json import DataToJson
 from parallelm.mlops.mlops_env_constants import MLOpsEnvConstants
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats_category import StatCategory, StatGraphType
-from pyspark.ml.pipeline import PipelineModel
-from pyspark.sql import DataFrame
-from google.protobuf.json_format import MessageToJson
 
 
 def str2bool(v):
@@ -66,7 +66,7 @@ class MLOpsPySparkChannel(MLOpsChannel):
     def done(self):
         self._jvm_mlops.done()
 
-    def stat(self, name, data, modelId, category=None, model=None, model_stat=None):
+    def stat(self, name, data, modelId, category=None, model=None, model_stat=None, **kwargs):
         if category in (StatCategory.CONFIG, StatCategory.TIME_SERIES):
             self._logger.info("{} stat called: name: {} data_type: {} class: {}".
                               format(Constants.OFFICIAL_NAME, name, type(data), category))

--- a/mlops/parallelm/mlops/metrics/confusion_matrix.py
+++ b/mlops/parallelm/mlops/metrics/confusion_matrix.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsException
+from parallelm.mlops.stats.table import Table
+from parallelm.protobuf.ReflexEvent_pb2 import ReflexEvent
+
+
+class ConfusionMatrix(object):
+
+    @staticmethod
+    def _set_confusion_matrix(cm_nd_array, model_id, stat_object_method, **kwargs):
+        labels = kwargs.get('labels', None)
+
+        if labels is not None:
+            if isinstance(cm_nd_array, np.ndarray) and isinstance(labels, list):
+                if len(cm_nd_array) == len(labels):
+                    # Output Confusion Matrix
+                    labels_string = [str(i) for i in labels]
+                    cm_matrix = Table().name(ClassificationMetrics.CONFUSION_MATRIX.value).cols(labels_string)
+
+                    for index in range(len(cm_nd_array)):
+                        cm_matrix.add_row(labels_string[index], list(cm_nd_array[index]))
+
+                    stat_object_method(mlops_stat=cm_matrix.get_mlops_stat(model_id=model_id),
+                                       reflex_event_message_type=ReflexEvent.StatsMessage)
+                else:
+                    raise MLOpsException(
+                        "Size of Confusion Matrix = {} and length of labels = {} does not match".format(
+                            len(cm_nd_array), len(labels)))
+            else:
+                raise MLOpsException(
+                    "Confusion Matrix should be of type numpy nd-array and labels should be of type list")
+
+        else:
+            raise MLOpsException(
+                "For outputting confusion matrix labels must be provided using extra `labels` argument to mlops apis.")

--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class ClassificationMetrics(Enum):
+    CONFUSION_MATRIX = "Confusion Matrix"

--- a/mlops/parallelm/mlops/mlops.py
+++ b/mlops/parallelm/mlops/mlops.py
@@ -30,7 +30,10 @@ from parallelm.mlops.events.system_alert import SystemAlert
 from parallelm.mlops.ion.ion import Agent
 from parallelm.mlops.logger_factory import logger_factory
 from parallelm.mlops.mlops_ctx import MLOpsCtx
-from parallelm.mlops.mlops_exception import MLOpsException, MLOpsConnectionException, SuppressException
+from parallelm.mlops.mlops_exception import MLOpsConnectionException, SuppressException
+from parallelm.mlops.mlops_exception import MLOpsException
+from parallelm.mlops.mlops_mode import MLOpsMode, OutputChannel
+from parallelm.mlops.mlops_rest_factory import MlOpsRestFactory
 from parallelm.mlops.models.model import Model
 from parallelm.mlops.models.model import ModelFormat
 from parallelm.mlops.models.model_filter import ModelFilter
@@ -40,8 +43,7 @@ from parallelm.mlops.stats.stats_helper import StatsHelper
 from parallelm.mlops.stats_category import StatCategory
 from parallelm.mlops.utils import time_to_str_timestamp_milli
 from parallelm.mlops.versions_info import mlops_version_info
-from parallelm.mlops.mlops_rest_factory import MlOpsRestFactory
-from parallelm.mlops.mlops_mode import MLOpsMode, OutputChannel
+
 
 # TODO: need to make the code thread safe - so in case of multiple threads this will not crash
 
@@ -384,8 +386,7 @@ class MLOps(object):
         """
         return self._curr_model
 
-    @SuppressException([MLOpsConnectionException])
-    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None):
+    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None, **kwargs):
         """
         Report this statistic.
 
@@ -396,7 +397,8 @@ class MLOps(object):
         :raises: MLOpsException
         """
         self._verify_mlops_is_ready()
-        self._stats_helper.set_stat(name, data, None, category, timestamp)
+        self._stats_helper.set_stat(name=name, data=data, model_id=None, category=category, timestamp=timestamp,
+                                    **kwargs)
 
     def set_kpi(self, name, data, timestamp=None, units=None):
         """
@@ -989,7 +991,6 @@ class MLOps(object):
 
         # calling init
         self.init(ctx=None, mlops_mode=MLOpsMode.ATTACH)
-
 
 
 # An instance of the MLOps to be used when importing the pm library.

--- a/mlops/parallelm/mlops/models/model.py
+++ b/mlops/parallelm/mlops/models/model.py
@@ -1,5 +1,6 @@
 import os
 from enum import Enum
+
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.models.mlobject import MLObject
 from parallelm.mlops.models.mlobject import MLObjectType
@@ -132,7 +133,7 @@ class Model(MLObject):
     def get_model_path(self):
         return self.model_path
 
-    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None):
+    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None, **kwargs):
         """
         Report this statistic.
         Statistic is attached to the current model and can be fetched later for this model.

--- a/mlops/parallelm/mlops/predefined_stats.py
+++ b/mlops/parallelm/mlops/predefined_stats.py
@@ -1,4 +1,3 @@
-
 class PredefinedStats:
     """
     Predefined statistics names which are interpreted by the MLOps center.


### PR DESCRIPTION
- We are going to support metrics for models. In this commit, api is not accepting extra **kwargs to get extra argument
- Extra argument helps in outputting stat correctly. For example, confusion matrixx needs labels as extra argument.
- We are starting with confusion matrix (classification)