### PR TITLE
[REF-6034] MLOps: Adding **kwargs To MLOps.set_stat

### DIFF
--- a/mlops/parallelm/mlops/channels/mlops_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_channel.py
@@ -3,8 +3,10 @@ Class representing the output channel to be used to report statistics/operations
 """
 
 import abc
-from parallelm.mlops.stats_category import StatCategory, StatsMode, StatGraphType
+
 from parallelm.mlops.stats.table import is_list_of_lists
+from parallelm.mlops.stats_category import StatCategory, StatsMode, StatGraphType
+
 
 class MLOpsChannel:
     """

--- a/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
@@ -1,18 +1,18 @@
 import json
 import os
+
 import pyspark
 import pyspark.mllib.common as ml
-import socket
-from google.protobuf.internal import encoder
+from google.protobuf.json_format import MessageToJson
+from pyspark.ml.pipeline import PipelineModel
+from pyspark.sql import DataFrame
+
 from parallelm.mlops.channels.mlops_channel import MLOpsChannel
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.data_to_json import DataToJson
 from parallelm.mlops.mlops_env_constants import MLOpsEnvConstants
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats_category import StatCategory, StatGraphType
-from pyspark.ml.pipeline import PipelineModel
-from pyspark.sql import DataFrame
-from google.protobuf.json_format import MessageToJson
 
 
 def str2bool(v):

--- a/mlops/parallelm/mlops/channels/mlops_python_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_python_channel.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from google.protobuf.json_format import MessageToJson
 from numpy.core.multiarray import ndarray
 
 from parallelm.mlops.channels.mlops_channel import MLOpsChannel
@@ -11,7 +12,6 @@ from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats.single_value import SingleValue
 from parallelm.mlops.stats_category import StatCategory
 from parallelm.protobuf.ReflexEvent_pb2 import ReflexEvent
-from google.protobuf.json_format import MessageToJson
 
 
 class MLOpsPythonChannel(MLOpsChannel):
@@ -28,8 +28,8 @@ class MLOpsPythonChannel(MLOpsChannel):
         pass
 
     def stat(self, name, data, model_id, category=None, model=None, model_stat=None):
-
         if category in (StatCategory.CONFIG, StatCategory.TIME_SERIES):
+
             self._logger.debug("{} stat called: name: {} data_type: {} class: {}".
                                format(Constants.OFFICIAL_NAME, name, type(data), category))
 
@@ -37,6 +37,7 @@ class MLOpsPythonChannel(MLOpsChannel):
             self.stat_object(single_value.get_mlops_stat(model_id))
 
         elif category is StatCategory.INPUT:
+
             self._logger.info("{} stat called: name: {} data_type: {} class: {}".
                               format(Constants.OFFICIAL_NAME, name, type(data), category))
 
@@ -75,6 +76,7 @@ class MLOpsPythonChannel(MLOpsChannel):
                                                                  model_id=model_id,
                                                                  num_bins=13)
         else:
+
             raise MLOpsException("stat_class: {} not supported yet".format(category))
 
     def stat_object(self, mlops_stat, reflex_event_message_type=ReflexEvent.StatsMessage):
@@ -104,12 +106,14 @@ class MLOpsPythonChannel(MLOpsChannel):
                 raise MLOpsException("Got an exception:{}".format(e))
 
         if feature_names:
-            important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx,name in enumerate(feature_names)]
+            important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx, name in
+                                        enumerate(feature_names)]
             return important_named_features
         else:
             try:
                 feature_names = df.columns[1:]
-                important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx,name in enumerate(feature_names)]
+                important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx, name in
+                                            enumerate(feature_names)]
                 return important_named_features
             except Exception as e:
                 raise MLOpsException("Got an exception:{}".format(e))

--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ClassificationMetrics(Enum):
+    """
+    Class will hold predefined naming of all classification ML Metrics supported by ParallelM.
+    """
+    CONFUSION_MATRIX = "Confusion Matrix"

--- a/mlops/parallelm/mlops/ml_metrics_stat/confusion_matrix.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/confusion_matrix.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsException
+from parallelm.mlops.stats.table import Table
+
+
+class ConfusionMatrix(object):
+    """
+    Responsibility of this class is basically creating table object out of input array and list of labels.
+    """
+
+    @staticmethod
+    def _get_mlops_cm_table_object(cm_nd_array, **kwargs):
+        """
+        Method will create MLOps Table stat object from ndarray and labels argument coming from kwargs
+        :param cm_nd_array: Array representation of confusion matrix
+        :param kwargs: `labels` used for representation of confusion matrix
+        :return: MLOps Table object generated from array
+        """
+        labels = kwargs.get('labels', None)
+
+        if labels is not None:
+            if isinstance(cm_nd_array, np.ndarray) and isinstance(labels, list):
+                if len(cm_nd_array) == len(labels):
+                    # Output Confusion Matrix
+                    labels_string = [str(i) for i in labels]
+                    cm_matrix = Table().name(ClassificationMetrics.CONFUSION_MATRIX.value).cols(labels_string)
+
+                    for index in range(len(cm_nd_array)):
+                        cm_matrix.add_row(labels_string[index], list(cm_nd_array[index]))
+
+                    return cm_matrix
+
+                else:
+                    raise MLOpsException(
+                        "Size of Confusion Matrix = {} and length of labels = {} does not match".format(
+                            len(cm_nd_array), len(labels)))
+            else:
+                raise MLOpsException(
+                    "Confusion Matrix should be of type numpy nd-array and labels should be of type list")
+
+        else:
+            raise MLOpsException(
+                "For outputting confusion matrix labels must be provided using extra `labels` argument to mlops apis.")
+
+        return None

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -1,0 +1,31 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.singelton import Singleton
+
+
+@Singleton
+class MLOpsMetrics(object):
+    """
+    Class is responsible for giving user sklearn alike code representation for using ParallelM's mlops apis.
+    Class will support classification, regression and clustering stats.
+    :Example:
+
+    >>> from parallelm.mlops import mlops
+
+    >>> # Output ML Stat - For Example Confusion Matrix as Table
+    >>> labels_pred = [1, 0 , 1] # prediction labels
+    >>> labels = [0, 1, 0] # actual labels
+    >>> labels_ordered = [0, 1] # order of labels to use for creating confusion matrix.
+
+    >>> mlops.metrics.confusion_matrix(y_true=labels, y_pred=labels_pred, labels=labels_ordered)
+    """
+
+    # classification stats
+    @staticmethod
+    def confusion_matrix(y_true, y_pred, labels, sample_weight=None):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        cm = sklearn.metrics.confusion_matrix(y_true, y_pred, labels, sample_weight)
+
+        mlops.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm, labels=labels)

--- a/mlops/parallelm/mlops/models/model.py
+++ b/mlops/parallelm/mlops/models/model.py
@@ -1,5 +1,6 @@
 import os
 from enum import Enum
+
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.models.mlobject import MLObject
 from parallelm.mlops.models.mlobject import MLObjectType
@@ -132,7 +133,7 @@ class Model(MLObject):
     def get_model_path(self):
         return self.model_path
 
-    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None):
+    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None, **kwargs):
         """
         Report this statistic.
         Statistic is attached to the current model and can be fetched later for this model.

--- a/mlops/parallelm/mlops/predefined_stats.py
+++ b/mlops/parallelm/mlops/predefined_stats.py
@@ -1,4 +1,3 @@
-
 class PredefinedStats:
     """
     Predefined statistics names which are interpreted by the MLOps center.

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -1,12 +1,15 @@
+import numpy as np
 import six
 
 from parallelm.mlops.base_obj import BaseObj
 from parallelm.mlops.constants import Constants
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.ml_metrics_stat.confusion_matrix import ConfusionMatrix
 from parallelm.mlops.mlops_exception import MLOpsException
-from parallelm.mlops.stats_category import StatCategory
+from parallelm.mlops.stats.bar_graph import BarGraph
 from parallelm.mlops.stats.kpi_value import KpiValue
 from parallelm.mlops.stats.mlops_stat_getter import MLOpsStatGetter
-from parallelm.mlops.stats.bar_graph import BarGraph
+from parallelm.mlops.stats_category import StatCategory
 
 
 class StatsHelper(BaseObj):
@@ -29,23 +32,62 @@ class StatsHelper(BaseObj):
                 raise MLOpsException("Only arrays of int or float are supported")
         elif isinstance(data, dict):
             pass
+        elif isinstance(data, np.ndarray):
+            pass
         else:
             raise MLOpsException("Type : {} is not yet supported by {}".
                                  format(type(data).__name__, Constants.OFFICIAL_NAME))
 
-    def set_stat(self, name, data, model_id, category, timestamp):
-        # If it supports the stat_object API, return the object.
+    def _set_classification_stat(self, name, data, model_id, timestamp, **kwargs):
+        mlops_stat_object = None
+        self._logger.debug("{} predefined stat called: name: {} data_type: {}".
+                           format(Constants.OFFICIAL_NAME, name, type(data)))
+
+        if name == ClassificationMetrics.CONFUSION_MATRIX:
+            mlops_stat_object = \
+                ConfusionMatrix._get_mlops_cm_table_object(cm_nd_array=data, **kwargs)
+
+        if mlops_stat_object is not None:
+            self.set_stat(name=name,
+                          data=mlops_stat_object,
+                          model_id=model_id,
+                          # type of stat will be General
+                          category=StatCategory.GENERAL,
+                          timestamp=timestamp, **kwargs)
+        else:
+            self._logger.error(
+                "{} predefined stat cannot be output as error happened in creating mlops stat object from {}"
+                    .format(name, data))
+
+    def set_stat(self, name, data, model_id, category, timestamp, **kwargs):
+
+        # If name supports the stat_object API, return the object.
         if isinstance(name, MLOpsStatGetter):
             self._output_channel.stat_object(name.get_mlops_stat(model_id))
             return self
 
+        # If data supports the stat_object API, return the object.
+        elif isinstance(data, MLOpsStatGetter):
+            self._output_channel.stat_object(data.get_mlops_stat(model_id))
+            return self
+
+        if name in ClassificationMetrics:
+            self._set_classification_stat(name=name,
+                                          data=data,
+                                          model_id=model_id,
+                                          timestamp=timestamp, **kwargs)
+
+            return self
+
         if category in (StatCategory.CONFIG, StatCategory.TIME_SERIES):
+
             self._logger.debug("{} stat called: name: {} data_type: {} class: {}".
                                format(Constants.OFFICIAL_NAME, name, type(data), category))
 
             self._validate_supported_conf_ts_data_type(data)
-            self._output_channel.stat(name, data, model_id, category)
+            self._output_channel.stat(name, data, model_id, category, **kwargs)
         else:
+
             raise MLOpsException("stat_class: {} not supported in set_stat call".format(category))
 
     def set_data_distribution_stat(self, data, model_id, model, timestamp):
@@ -66,7 +108,8 @@ class StatsHelper(BaseObj):
 
         self._output_channel.stat_object(kpi_value.get_mlops_stat(model_id))
 
-    def feature_importance(self, model_obj, feature_importance_vector=None, feature_names=None, model=None, df=None, num_significant_features=100):
+    def feature_importance(self, model_obj, feature_importance_vector=None, feature_names=None, model=None, df=None,
+                           num_significant_features=100):
         """
          present feature importance, either according to the provided vector or generated from
          the provided model if available.
@@ -95,7 +138,8 @@ class StatsHelper(BaseObj):
 
         self._validate_feature_importance_inputs(feature_importance_vector, feature_names, model, df)
 
-        important_named_features = self._output_channel.feature_importance(feature_importance_vector, feature_names, model, df)
+        important_named_features = self._output_channel.feature_importance(feature_importance_vector, feature_names,
+                                                                           model, df)
 
         if important_named_features:
             # Sort the feature importance vector
@@ -116,7 +160,8 @@ class StatsHelper(BaseObj):
             bar = BarGraph().name("Feature Importance").cols(col_names).data(col_value)
             model_obj.set_stat(bar)
 
-    def _validate_feature_importance_inputs(self, feature_importance_vector=None, feature_names=None, model=None, df=None):
+    def _validate_feature_importance_inputs(self, feature_importance_vector=None, feature_names=None, model=None,
+                                            df=None):
         """
         verify common parameters. specific parameters are verified in each output channel
         :param feature_importance_vector: feature importance vector optional
@@ -138,11 +183,12 @@ class StatsHelper(BaseObj):
                 raise MLOpsException("features importance vector must be a list")
             for feature_importance_element in feature_importance_vector:
                 if not isinstance(feature_importance_element, (six.integer_types, float)):
-                    raise MLOpsException("features importance elements must be a number. got: {} ".format(feature_importance_element))
+                    raise MLOpsException(
+                        "features importance elements must be a number. got: {} ".format(feature_importance_element))
         if feature_names:
             if not isinstance(feature_names, list):
                 raise MLOpsException("features names vector must be a list")
             for feature_names_element in feature_names:
                 if not isinstance(feature_names_element, six.string_types):
-                    raise MLOpsException("features name elements must be a string. got: {} ".format(feature_names_element))
-
+                    raise MLOpsException(
+                        "features name elements must be a string. got: {} ".format(feature_names_element))

--- a/mlops/setup.py
+++ b/mlops/setup.py
@@ -42,7 +42,7 @@ setup(
         "kazoo",
         "protobuf",
         "requests",
-        "py4j"
+        "py4j", 'scikit-learn'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={


### PR DESCRIPTION
- We are going to support metrics for models. In this commit, api is not accepting extra **kwargs to get extra argument
- Extra argument helps in outputting stat correctly. For example, confusion matrixx needs labels as extra argument.
- We are starting with confusion matrix (classification)