### PR TITLE
[REF-6034] MLOps: Adding **kwargs To MLOps.set_stat

### DIFF
--- a/mlops/parallelm/mlops/channels/mlops_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_channel.py
@@ -3,8 +3,10 @@ Class representing the output channel to be used to report statistics/operations
 """
 
 import abc
-from parallelm.mlops.stats_category import StatCategory, StatsMode, StatGraphType
+
 from parallelm.mlops.stats.table import is_list_of_lists
+from parallelm.mlops.stats_category import StatCategory, StatsMode, StatGraphType
+
 
 class MLOpsChannel:
     """

--- a/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_pyspark_channel.py
@@ -1,18 +1,18 @@
 import json
 import os
+
 import pyspark
 import pyspark.mllib.common as ml
-import socket
-from google.protobuf.internal import encoder
+from google.protobuf.json_format import MessageToJson
+from pyspark.ml.pipeline import PipelineModel
+from pyspark.sql import DataFrame
+
 from parallelm.mlops.channels.mlops_channel import MLOpsChannel
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.data_to_json import DataToJson
 from parallelm.mlops.mlops_env_constants import MLOpsEnvConstants
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats_category import StatCategory, StatGraphType
-from pyspark.ml.pipeline import PipelineModel
-from pyspark.sql import DataFrame
-from google.protobuf.json_format import MessageToJson
 
 
 def str2bool(v):

--- a/mlops/parallelm/mlops/channels/mlops_python_channel.py
+++ b/mlops/parallelm/mlops/channels/mlops_python_channel.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from google.protobuf.json_format import MessageToJson
 from numpy.core.multiarray import ndarray
 
 from parallelm.mlops.channels.mlops_channel import MLOpsChannel
@@ -11,7 +12,6 @@ from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.stats.single_value import SingleValue
 from parallelm.mlops.stats_category import StatCategory
 from parallelm.protobuf.ReflexEvent_pb2 import ReflexEvent
-from google.protobuf.json_format import MessageToJson
 
 
 class MLOpsPythonChannel(MLOpsChannel):
@@ -28,7 +28,6 @@ class MLOpsPythonChannel(MLOpsChannel):
         pass
 
     def stat(self, name, data, model_id, category=None, model=None, model_stat=None):
-
         if category in (StatCategory.CONFIG, StatCategory.TIME_SERIES):
             self._logger.debug("{} stat called: name: {} data_type: {} class: {}".
                                format(Constants.OFFICIAL_NAME, name, type(data), category))
@@ -104,12 +103,14 @@ class MLOpsPythonChannel(MLOpsChannel):
                 raise MLOpsException("Got an exception:{}".format(e))
 
         if feature_names:
-            important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx,name in enumerate(feature_names)]
+            important_named_features = [[name, feature_importance_vector_final[imp_idx]]
+                                        for imp_idx, name in enumerate(feature_names)]
             return important_named_features
         else:
             try:
                 feature_names = df.columns[1:]
-                important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx,name in enumerate(feature_names)]
+                important_named_features = [[name, feature_importance_vector_final[imp_idx]] for imp_idx, name in
+                                            enumerate(feature_names)]
                 return important_named_features
             except Exception as e:
                 raise MLOpsException("Got an exception:{}".format(e))

--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ClassificationMetrics(Enum):
+    """
+    Class will hold predefined naming of all classification ML Metrics supported by ParallelM.
+    """
+    CONFUSION_MATRIX = "Confusion Matrix"

--- a/mlops/parallelm/mlops/ml_metrics_stat/confusion_matrix.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/confusion_matrix.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.table import Table
+
+
+class ConfusionMatrix(object):
+    """
+    Responsibility of this class is basically creating table object out of input array and list of labels.
+    """
+
+    @staticmethod
+    def get_mlops_cm_table_object(cm_nd_array, **kwargs):
+        """
+        Method will create MLOps Table stat object from ndarray and labels argument coming from kwargs (`labels`).
+        It is not recommended to access this method without understanding table data structure that it is returning.
+        :param cm_nd_array: Array representation of confusion matrix
+        :param kwargs: `labels` used for representation of confusion matrix
+        :return: MLOps Table object generated from array
+        """
+        labels = kwargs.get('labels', None)
+
+        if labels is not None:
+            if isinstance(cm_nd_array, np.ndarray) and isinstance(labels, list):
+                if len(cm_nd_array) == len(labels):
+                    # Output Confusion Matrix
+                    labels_string = [str(i) for i in labels]
+                    cm_matrix = Table().name(ClassificationMetrics.CONFUSION_MATRIX.value).cols(labels_string)
+
+                    for index in range(len(cm_nd_array)):
+                        cm_matrix.add_row(labels_string[index], list(cm_nd_array[index]))
+
+                    return cm_matrix
+
+                else:
+                    raise MLOpsStatisticsException \
+                        ("Size of Confusion Matrix = {} and length of labels = {} does not match"
+                         .format(len(cm_nd_array), len(labels)))
+            else:
+                raise MLOpsStatisticsException \
+                    ("Confusion Matrix should be of type numpy nd-array and labels should be of type list")
+
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting confusion matrix labels must be provided using extra `labels` argument to mlops apis.")
+
+        return None

--- a/mlops/parallelm/mlops/mlops_exception.py
+++ b/mlops/parallelm/mlops/mlops_exception.py
@@ -16,6 +16,13 @@ class MLOpsConnectionException(MLOpsException):
     pass
 
 
+class MLOpsStatisticsException(MLOpsException):
+    """
+    Exception that will be returned by the MLOps class on ML stat creation error
+    """
+    pass
+
+
 """
 SuppressException decorator can be used to suppress Exceptions.
 
@@ -45,8 +52,8 @@ SuppressException.exclude([B]) # only A will be suppressed
 
 + maybe add return value for suppression definition.
 """
-    
-    
+
+
 class SuppressException(object):
     _suppress = False
 

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -1,0 +1,31 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.singelton import Singleton
+
+
+@Singleton
+class MLOpsMetrics(object):
+    """
+    Class is responsible for giving user sklearn alike code representation for using ParallelM's mlops apis.
+    Class will support classification, regression and clustering stats.
+    :Example:
+
+    >>> from parallelm.mlops import mlops
+
+    >>> # Output ML Stat - For Example Confusion Matrix as Table
+    >>> labels_pred = [1, 0 , 1] # prediction labels
+    >>> labels = [0, 1, 0] # actual labels
+    >>> labels_ordered = [0, 1] # order of labels to use for creating confusion matrix.
+
+    >>> mlops.metrics.confusion_matrix(y_true=labels, y_pred=labels_pred, labels=labels_ordered)
+    """
+
+    # classification stats
+    @staticmethod
+    def confusion_matrix(y_true, y_pred, labels, sample_weight=None):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        cm = sklearn.metrics.confusion_matrix(y_true, y_pred, labels, sample_weight)
+
+        mlops.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm, labels=labels)

--- a/mlops/parallelm/mlops/models/model.py
+++ b/mlops/parallelm/mlops/models/model.py
@@ -1,5 +1,6 @@
 import os
 from enum import Enum
+
 from parallelm.mlops.mlops_exception import MLOpsException
 from parallelm.mlops.models.mlobject import MLObject
 from parallelm.mlops.models.mlobject import MLObjectType
@@ -132,7 +133,7 @@ class Model(MLObject):
     def get_model_path(self):
         return self.model_path
 
-    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None):
+    def set_stat(self, name, data=None, category=StatCategory.TIME_SERIES, timestamp=None, **kwargs):
         """
         Report this statistic.
         Statistic is attached to the current model and can be fetched later for this model.

--- a/mlops/parallelm/mlops/predefined_stats.py
+++ b/mlops/parallelm/mlops/predefined_stats.py
@@ -1,4 +1,3 @@
-
 class PredefinedStats:
     """
     Predefined statistics names which are interpreted by the MLOps center.

--- a/mlops/setup.py
+++ b/mlops/setup.py
@@ -1,7 +1,9 @@
 import os
+
 from setuptools import setup, find_packages
 
 import protobuf_dep
+
 protobuf_dep.copy_protobuf_sources()
 
 from parallelm.mlops.constants import Constants
@@ -42,7 +44,8 @@ setup(
         "kazoo",
         "protobuf",
         "requests",
-        "py4j"
+        "py4j",
+        "scikit-learn"
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={

--- a/mlops/tests/test_mlops.py
+++ b/mlops/tests/test_mlops.py
@@ -7,15 +7,17 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests_mock
-
 from ion_test_helper import set_mlops_env, ION1, test_models_info, test_health_info
 from ion_test_helper import test_workflow_instances, test_ee_info, test_agents_info
+from sklearn import metrics
+
 from parallelm.mlops import Versions
 from parallelm.mlops import mlops as pm
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.events.event_type import EventType
 from parallelm.mlops.ion.ion import Agent
-from parallelm.mlops.mlops_exception import MLOpsException, MLOpsConnectionException
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsException, MLOpsConnectionException, MLOpsStatisticsException
 from parallelm.mlops.mlops_mode import MLOpsMode
 from parallelm.mlops.mlops_rest_factory import MlOpsRestFactory
 from parallelm.mlops.models.model import ModelFormat
@@ -291,6 +293,43 @@ def test_general_graph():
 
     gg = Graph().name("gg").set_x_series(x_series).add_y_series(label="y1", data=y1)
     pm.set_stat(gg)
+    pm.done()
+
+
+def test_mlops_confusion_metrics_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1, 0, 1, 1, 1, 0]
+    labels_actual = [0, 1, 0, 0, 0, 1]
+    labels_ordered = [0, 1]
+
+    cm = metrics.confusion_matrix(labels_actual, labels_pred, labels=labels_ordered)
+
+    # first way
+    pm.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm, labels=labels_ordered)
+
+    # second way
+    pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred, labels=labels_ordered)
+
+    # should throw error if labels are not provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm)
+
+    with pytest.raises(MLOpsStatisticsException):
+        pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred, labels=None)
+
+    with pytest.raises(ValueError):
+        labels_pred_missing_values = [0, 0, 0, 1]
+        pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred_missing_values, labels=None)
+
+    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
+
+    # testing with sample weights as well
+    pm.metrics.confusion_matrix(y_true=labels_actual,
+                                y_pred=labels_pred,
+                                labels=labels_ordered,
+                                sample_weight=sample_weight)
+
     pm.done()
 
 


### PR DESCRIPTION
- We are going to support metrics for models. In this commit, api is not accepting extra **kwargs to get extra argument
- Extra argument helps in outputting stat correctly. For example, confusion matrixx needs labels as extra argument.
- We are starting with confusion matrix (classification)