### PR TITLE
[REF-6034] AccuracyScore: Adding MLOps Classification Metrics - Accuracy Score

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -6,3 +6,4 @@ class ClassificationMetrics(Enum):
     Class will hold predefined naming of all classification ML Metrics supported by ParallelM.
     """
     CONFUSION_MATRIX = "Confusion Matrix"
+    ACCURACY_SCORE = "Accuracy Score"

--- a/mlops/parallelm/mlops/ml_metrics_stat/accuracy_score.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/accuracy_score.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class AccuracyScore(object):
+    """
+    Responsibility of this class is basically creating stat object out of accuracy score.
+    """
+
+    @staticmethod
+    def get_mlops_accuracy_stat_object(accuracy_score):
+        """
+        Method will create MLOps Single value stat object from numeric real number - accuracy score
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param accuracy_score: numeric value of accuracy
+        :return: Single Value stat object which has accuracy score embedded inside
+        """
+        single_value = None
+
+        if isinstance(accuracy_score, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(ClassificationMetrics.ACCURACY_SCORE.value) \
+                    .value(accuracy_score) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting accuracy score, accuracy should be of type numeric but got {}."
+                 .format(type(accuracy_score)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -21,6 +21,17 @@ class MLOpsMetrics(object):
 
     # classification stats
     @staticmethod
+    def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        accuracy_score = sklearn.metrics.accuracy_score(y_true=y_true, y_pred=y_pred, normalize=normalize,
+                                                        sample_weight=sample_weight)
+
+        mlops.set_stat(ClassificationMetrics.ACCURACY_SCORE, data=accuracy_score)
+
+    @staticmethod
     def confusion_matrix(y_true, y_pred, labels, sample_weight=None):
         # need to import only on run time.
         from parallelm.mlops import mlops as mlops
@@ -28,4 +39,4 @@ class MLOpsMetrics(object):
 
         cm = sklearn.metrics.confusion_matrix(y_true, y_pred, labels, sample_weight)
 
-        mlops.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm, labels=labels)
+        mlops.set_stat(ClassificationMetrics.CONFUSION_MATRIX, data=cm, labels=labels)

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -4,6 +4,7 @@ import six
 from parallelm.mlops.base_obj import BaseObj
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.ml_metrics_stat.accuracy_score import AccuracyScore
 from parallelm.mlops.ml_metrics_stat.confusion_matrix import ConfusionMatrix
 from parallelm.mlops.mlops_exception import MLOpsException, MLOpsStatisticsException
 from parallelm.mlops.stats.bar_graph import BarGraph
@@ -40,6 +41,8 @@ class StatsHelper(BaseObj):
 
     def _set_classification_stat(self, name, data, model_id, timestamp, **kwargs):
         mlops_stat_object = None
+        category = StatCategory.GENERAL
+
         self._logger.debug("{} predefined stat called: name: {} data_type: {}".
                            format(Constants.OFFICIAL_NAME, name, type(data)))
 
@@ -47,16 +50,23 @@ class StatsHelper(BaseObj):
             mlops_stat_object = \
                 ConfusionMatrix.get_mlops_cm_table_object(cm_nd_array=data, **kwargs)
 
+        elif name == ClassificationMetrics.ACCURACY_SCORE:
+            mlops_stat_object = \
+                AccuracyScore.get_mlops_accuracy_stat_object(accuracy_score=data)
+            category = StatCategory.TIME_SERIES
+
         if mlops_stat_object is not None:
             self.set_stat(name=name,
                           data=mlops_stat_object,
                           model_id=model_id,
                           # type of stat will be General
-                          category=StatCategory.GENERAL,
-                          timestamp=timestamp, **kwargs)
+                          category=category,
+                          timestamp=timestamp,
+                          **kwargs)
         else:
-            error = "{} predefined stat cannot be output as error happened in creating mlops stat object from {}".format(
-                name, data)
+            error = "{} predefined stat cannot be output as error happened in creating mlops stat object from {}" \
+                .format(name, data)
+
             raise MLOpsStatisticsException(error)
 
     def set_stat(self, name, data, model_id, category, timestamp, **kwargs):

--- a/mlops/tests/test_metrics.py
+++ b/mlops/tests/test_metrics.py
@@ -1,0 +1,78 @@
+import pytest
+from sklearn import metrics
+
+from parallelm.mlops import mlops as pm
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.mlops_mode import MLOpsMode
+
+
+def test_mlops_accuracy_score_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1, 0, 1, 1, 1, 0]
+    labels_actual = [0, 1, 0, 0, 0, 1]
+
+    accuracy_score = metrics.accuracy_score(labels_actual, labels_pred)
+
+    # first way
+    pm.set_stat(ClassificationMetrics.ACCURACY_SCORE, accuracy_score)
+
+    # second way
+    pm.metrics.accuracy_score(y_true=labels_actual, y_pred=labels_pred)
+
+    # should throw error if not numeric number is provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(ClassificationMetrics.ACCURACY_SCORE, [1, 2, 3])
+
+    # should throw error if labels predicted is different length than actuals
+    with pytest.raises(ValueError):
+        labels_pred_missing_values = [0, 0, 0, 1]
+        pm.metrics.accuracy_score(y_true=labels_actual, y_pred=labels_pred_missing_values)
+
+    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
+
+    # testing with sample weights as well
+    pm.metrics.accuracy_score(y_true=labels_actual,
+                              y_pred=labels_pred,
+                              sample_weight=sample_weight)
+
+    pm.done()
+
+
+def test_mlops_confusion_metrics_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1, 0, 1, 1, 1, 0]
+    labels_actual = [0, 1, 0, 0, 0, 1]
+    labels_ordered = [0, 1]
+
+    cm = metrics.confusion_matrix(labels_actual, labels_pred, labels=labels_ordered)
+
+    # first way
+    pm.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm, labels=labels_ordered)
+
+    # second way
+    pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred, labels=labels_ordered)
+
+    # should throw error if labels are not provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm)
+
+    with pytest.raises(MLOpsStatisticsException):
+        pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred, labels=None)
+
+    # should throw error if labels predicted is different length than actuals
+    with pytest.raises(ValueError):
+        labels_pred_missing_values = [0, 0, 0, 1]
+        pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred_missing_values, labels=None)
+
+    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
+
+    # testing with sample weights as well
+    pm.metrics.confusion_matrix(y_true=labels_actual,
+                                y_pred=labels_pred,
+                                labels=labels_ordered,
+                                sample_weight=sample_weight)
+
+    pm.done()

--- a/mlops/tests/test_mlops.py
+++ b/mlops/tests/test_mlops.py
@@ -9,15 +9,13 @@ import pytest
 import requests_mock
 from ion_test_helper import set_mlops_env, ION1, test_models_info, test_health_info
 from ion_test_helper import test_workflow_instances, test_ee_info, test_agents_info
-from sklearn import metrics
 
 from parallelm.mlops import Versions
 from parallelm.mlops import mlops as pm
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.events.event_type import EventType
 from parallelm.mlops.ion.ion import Agent
-from parallelm.mlops.metrics_constants import ClassificationMetrics
-from parallelm.mlops.mlops_exception import MLOpsException, MLOpsConnectionException, MLOpsStatisticsException
+from parallelm.mlops.mlops_exception import MLOpsException, MLOpsConnectionException
 from parallelm.mlops.mlops_mode import MLOpsMode
 from parallelm.mlops.mlops_rest_factory import MlOpsRestFactory
 from parallelm.mlops.models.model import ModelFormat
@@ -293,43 +291,6 @@ def test_general_graph():
 
     gg = Graph().name("gg").set_x_series(x_series).add_y_series(label="y1", data=y1)
     pm.set_stat(gg)
-    pm.done()
-
-
-def test_mlops_confusion_metrics_apis():
-    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
-
-    labels_pred = [1, 0, 1, 1, 1, 0]
-    labels_actual = [0, 1, 0, 0, 0, 1]
-    labels_ordered = [0, 1]
-
-    cm = metrics.confusion_matrix(labels_actual, labels_pred, labels=labels_ordered)
-
-    # first way
-    pm.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm, labels=labels_ordered)
-
-    # second way
-    pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred, labels=labels_ordered)
-
-    # should throw error if labels are not provided
-    with pytest.raises(MLOpsStatisticsException):
-        pm.set_stat(ClassificationMetrics.CONFUSION_MATRIX, cm)
-
-    with pytest.raises(MLOpsStatisticsException):
-        pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred, labels=None)
-
-    with pytest.raises(ValueError):
-        labels_pred_missing_values = [0, 0, 0, 1]
-        pm.metrics.confusion_matrix(y_true=labels_actual, y_pred=labels_pred_missing_values, labels=None)
-
-    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
-
-    # testing with sample weights as well
-    pm.metrics.confusion_matrix(y_true=labels_actual,
-                                y_pred=labels_pred,
-                                labels=labels_ordered,
-                                sample_weight=sample_weight)
-
     pm.done()
 
 


### PR DESCRIPTION
[REF-6034] AccuracyScore: Adding MLOps Classification Metrics - Accuracy Score
Usages:
    labels_pred = [1, 0, 1, 1, 1, 0]
    labels_actual = [0, 1, 0, 0, 0, 1]

    accuracy_score = sklearn.metrics.accuracy_score(labels_actual, labels_pred)

    # first way
    pm.set_stat(ClassificationMetrics.ACCURACY_SCORE, accuracy_score)

    # second way
    pm.metrics.accuracy_score(y_true=labels_actual, y_pred=labels_pred)

    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]

    # testing with sample weights as well
    pm.metrics.accuracy_score(y_true=labels_actual,
                              y_pred=labels_pred,
                              sample_weight=sample_weight)
Testing Done:
- Unit Test