### PR TITLE
    [REF-6034] AUCScore: Adding MLOps Classification Metrics - AUC Score

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -5,5 +5,6 @@ class ClassificationMetrics(Enum):
     """
     Class will hold predefined naming of all classification ML Metrics supported by ParallelM.
     """
-    CONFUSION_MATRIX = "Confusion Matrix"
     ACCURACY_SCORE = "Accuracy Score"
+    AUC = "AUC(Area Under the Curve)"
+    CONFUSION_MATRIX = "Confusion Matrix"

--- a/mlops/parallelm/mlops/ml_metrics_stat/auc.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/auc.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class AUC(object):
+    """
+    Responsibility of this class is basically creating stat object out of auc score.
+    """
+
+    @staticmethod
+    def get_mlops_auc_stat_object(auc):
+        """
+        Method will create MLOps Single value stat object from numeric real number - auc score
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param auc: numeric value of auc
+        :return: Single Value stat object which has auc score embedded inside
+        """
+        single_value = None
+
+        if isinstance(auc, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(ClassificationMetrics.AUC.value) \
+                    .value(auc) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting accuracy score, accuracy should be of type numeric but got {}."
+                 .format(type(auc)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -16,6 +16,12 @@ class MLOpsMetrics(object):
     >>> labels = [0, 1, 0] # actual labels
     >>> labels_ordered = [0, 1] # order of labels to use for creating confusion matrix.
 
+    >>> mlops.metrics.accuracy_score(y_true=labels, y_pred=labels_pred)
+
+    >>> fpr, tpr, thresholds = sklearn.metrics.roc_curve(labels, labels_pred, pos_label=2)
+
+    >>> mlops.metrics.auc(x=fpr, y=tpr)
+
     >>> mlops.metrics.confusion_matrix(y_true=labels, y_pred=labels_pred, labels=labels_ordered)
     """
 
@@ -30,6 +36,16 @@ class MLOpsMetrics(object):
                                                         sample_weight=sample_weight)
 
         mlops.set_stat(ClassificationMetrics.ACCURACY_SCORE, data=accuracy_score)
+
+    @staticmethod
+    def auc(x, y):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        auc = sklearn.metrics.auc(x=x, y=y)
+
+        mlops.set_stat(ClassificationMetrics.AUC, data=auc)
 
     @staticmethod
     def confusion_matrix(y_true, y_pred, labels, sample_weight=None):

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -5,6 +5,7 @@ from parallelm.mlops.base_obj import BaseObj
 from parallelm.mlops.constants import Constants
 from parallelm.mlops.metrics_constants import ClassificationMetrics
 from parallelm.mlops.ml_metrics_stat.accuracy_score import AccuracyScore
+from parallelm.mlops.ml_metrics_stat.auc import AUC
 from parallelm.mlops.ml_metrics_stat.confusion_matrix import ConfusionMatrix
 from parallelm.mlops.mlops_exception import MLOpsException, MLOpsStatisticsException
 from parallelm.mlops.stats.bar_graph import BarGraph
@@ -53,6 +54,11 @@ class StatsHelper(BaseObj):
         elif name == ClassificationMetrics.ACCURACY_SCORE:
             mlops_stat_object = \
                 AccuracyScore.get_mlops_accuracy_stat_object(accuracy_score=data)
+            category = StatCategory.TIME_SERIES
+
+        elif name == ClassificationMetrics.AUC:
+            mlops_stat_object = \
+                AUC.get_mlops_auc_stat_object(auc=data)
             category = StatCategory.TIME_SERIES
 
         if mlops_stat_object is not None:

--- a/mlops/tests/test_metrics.py
+++ b/mlops/tests/test_metrics.py
@@ -1,4 +1,5 @@
 import pytest
+import sklearn
 from sklearn import metrics
 
 from parallelm.mlops import mlops as pm
@@ -36,6 +37,28 @@ def test_mlops_accuracy_score_apis():
     pm.metrics.accuracy_score(y_true=labels_actual,
                               y_pred=labels_pred,
                               sample_weight=sample_weight)
+
+    pm.done()
+
+
+def test_mlops_auc_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1, 0, 1, 1, 1, 0]
+    labels_actual = [0, 1, 0, 0, 0, 1]
+
+    fpr, tpr, thresholds = sklearn.metrics.roc_curve(labels_actual, labels_pred, pos_label=2)
+    auc = sklearn.metrics.auc(fpr, tpr)
+
+    # first way
+    pm.set_stat(ClassificationMetrics.AUC, auc)
+
+    # second way
+    pm.metrics.auc(x=fpr, y=tpr)
+
+    # should throw error if not numeric number is provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(ClassificationMetrics.AUC, [1, 2, 3])
 
     pm.done()
 


### PR DESCRIPTION
    [REF-6034] AUCScore: Adding MLOps Classification Metrics - AUC Score

    Usages:
        labels_pred = [1, 0, 1, 1, 1, 0]
        labels_actual = [0, 1, 0, 0, 0, 1]

        fpr, tpr, thresholds = sklearn.metrics.roc_curve(labels_actual, labels_pred, pos_label=2)
        auc = sklearn.metrics.auc(fpr, tpr)

        # first way
        pm.set_stat(ClassificationMetrics.AUC, auc)

        # second way
        pm.metrics.auc(x=fpr, y=tpr)

    Testing Done
    - Unit Test