### PR TITLE
[REF-6034] AveragePrecisionScore: Adding MLOps Classification Metrics…

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -7,4 +7,5 @@ class ClassificationMetrics(Enum):
     """
     ACCURACY_SCORE = "Accuracy Score"
     AUC = "AUC(Area Under the Curve)"
+    AVERAGE_PRECISION_SCORE = "Average Precision Score"
     CONFUSION_MATRIX = "Confusion Matrix"

--- a/mlops/parallelm/mlops/ml_metrics_stat/average_precision_score.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/average_precision_score.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class AveragePrecisionScore(object):
+    """
+    Responsibility of this class is basically creating stat object out of average precision score.
+    """
+
+    @staticmethod
+    def get_mlops_aps_stat_object(aps):
+        """
+        Method will create MLOps Single value stat object from numeric real number - average precision score
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param aps: numeric value of average precision score
+        :return: Single Value stat object which has aps score embedded inside
+        """
+        single_value = None
+
+        if isinstance(aps, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(ClassificationMetrics.AVERAGE_PRECISION_SCORE.value) \
+                    .value(aps) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting average precision score, value should be of type numeric but got {}."
+                 .format(type(aps)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -12,15 +12,18 @@ class MLOpsMetrics(object):
     >>> from parallelm.mlops import mlops
 
     >>> # Output ML Stat - For Example Confusion Matrix as Table
-    >>> labels_pred = [1, 0 , 1] # prediction labels
+    >>> labels_pred = [1, 0, 1] # prediction labels
     >>> labels = [0, 1, 0] # actual labels
     >>> labels_ordered = [0, 1] # order of labels to use for creating confusion matrix.
+    >>> labels_decision_values = [0.9, 0.85, 0.9] # distance from hyper plane
 
     >>> mlops.metrics.accuracy_score(y_true=labels, y_pred=labels_pred)
 
     >>> fpr, tpr, thresholds = sklearn.metrics.roc_curve(labels, labels_pred, pos_label=2)
 
     >>> mlops.metrics.auc(x=fpr, y=tpr)
+
+    >>> pm.metrics.average_precision_score(y_true=labels_pred, y_score=labels_decision_values)
 
     >>> mlops.metrics.confusion_matrix(y_true=labels, y_pred=labels_pred, labels=labels_ordered)
     """
@@ -38,14 +41,27 @@ class MLOpsMetrics(object):
         mlops.set_stat(ClassificationMetrics.ACCURACY_SCORE, data=accuracy_score)
 
     @staticmethod
-    def auc(x, y):
+    def auc(x, y, reorder="deprecated"):
         # need to import only on run time.
         from parallelm.mlops import mlops as mlops
         import sklearn
 
-        auc = sklearn.metrics.auc(x=x, y=y)
+        auc = sklearn.metrics.auc(x=x, y=y, reorder=reorder)
 
         mlops.set_stat(ClassificationMetrics.AUC, data=auc)
+
+    @staticmethod
+    def average_precision_score(y_true, y_score, average="macro", sample_weight=None):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        aps = sklearn.metrics.average_precision_score(y_true=y_true,
+                                                      y_score=y_score,
+                                                      average=average,
+                                                      sample_weight=sample_weight)
+
+        mlops.set_stat(ClassificationMetrics.AVERAGE_PRECISION_SCORE, data=aps)
 
     @staticmethod
     def confusion_matrix(y_true, y_pred, labels, sample_weight=None):

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -6,6 +6,7 @@ from parallelm.mlops.constants import Constants
 from parallelm.mlops.metrics_constants import ClassificationMetrics
 from parallelm.mlops.ml_metrics_stat.accuracy_score import AccuracyScore
 from parallelm.mlops.ml_metrics_stat.auc import AUC
+from parallelm.mlops.ml_metrics_stat.average_precision_score import AveragePrecisionScore
 from parallelm.mlops.ml_metrics_stat.confusion_matrix import ConfusionMatrix
 from parallelm.mlops.mlops_exception import MLOpsException, MLOpsStatisticsException
 from parallelm.mlops.stats.bar_graph import BarGraph
@@ -59,6 +60,11 @@ class StatsHelper(BaseObj):
         elif name == ClassificationMetrics.AUC:
             mlops_stat_object = \
                 AUC.get_mlops_auc_stat_object(auc=data)
+            category = StatCategory.TIME_SERIES
+
+        elif name == ClassificationMetrics.AVERAGE_PRECISION_SCORE:
+            mlops_stat_object = \
+                AveragePrecisionScore.get_mlops_aps_stat_object(aps=data)
             category = StatCategory.TIME_SERIES
 
         if mlops_stat_object is not None:

--- a/mlops/tests/test_metrics.py
+++ b/mlops/tests/test_metrics.py
@@ -63,6 +63,32 @@ def test_mlops_auc_apis():
     pm.done()
 
 
+def test_mlops_aps_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1, 0, 1, 1, 1, 0]
+    labels_decision_score = [0.9, 0.1, 0.9, 0.5, 0.1, 0.1]
+
+    aps = sklearn.metrics.average_precision_score(labels_pred, labels_decision_score)
+
+    # first way
+    pm.set_stat(ClassificationMetrics.AVERAGE_PRECISION_SCORE, aps)
+
+    # second way
+    pm.metrics.average_precision_score(y_true=labels_pred, y_score=labels_decision_score)
+
+    # should throw error if not numeric number is provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(ClassificationMetrics.AVERAGE_PRECISION_SCORE, [1, 2, 3])
+
+    # should throw error if labels decision values' length is different length than actuals
+    with pytest.raises(ValueError):
+        labels_decision_score_some_missing = [0.9, 0.1, 0.9, 0.5, 0.1]
+        pm.metrics.average_precision_score(y_true=labels_pred, y_score=labels_decision_score_some_missing)
+
+    pm.done()
+
+
 def test_mlops_confusion_metrics_apis():
     pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
 


### PR DESCRIPTION
… - Average Precision Score

Usages:
	labels_pred = [1, 0, 1, 1, 1, 0]
	labels_decision_score = [0.9, 0.1, 0.9, 0.5, 0.1, 0.1]

    	aps = sklearn.metrics.average_precision_score(labels_pred, labels_decision_score)

    	# first way
    	mlops.set_stat(ClassificationMetrics.AVERAGE_PRECISION_SCORE, aps)

    	# second way
    	mlops.metrics.average_precision_score(y_true=labels_pred, y_score=labels_decision_score)

Testing Done
	- Unit Test