### PR TITLE
[REF-6034] MeanSquaredLogError: Adding MLOps Regression Metrics - Mea…

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -18,3 +18,4 @@ class RegressionMetrics(Enum):
     EXPLAINED_VARIANCE_SCORE = "Explained Variance Score"
     MEAN_ABSOLUTE_ERROR = "Mean Absolute Error"
     MEAN_SQUARED_ERROR = "Mean Squared Error"
+    MEAN_SQUARED_LOG_ERROR = "Mean Squared Log Error"

--- a/mlops/parallelm/mlops/ml_metrics_stat/regression/mean_squared_log_error.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/regression/mean_squared_log_error.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import RegressionMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class MeanSquaredLogError(object):
+    """
+    Responsibility of this class is basically creating stat object out of mean squared log error.
+    """
+
+    @staticmethod
+    def get_mlops_msle_stat_object(msle):
+        """
+        Method will create MLOps Single value stat object from numeric real number - mean squared log error
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param msle: mean squared log error
+        :return: Single Value stat object which has mean squared log error embedded inside
+        """
+        single_value = None
+
+        if isinstance(msle, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(RegressionMetrics.MEAN_SQUARED_LOG_ERROR.value) \
+                    .value(msle) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting mean squared error, mse should be of type numeric but got {}."
+                 .format(type(msle)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -128,3 +128,16 @@ class MLOpsMetrics(object):
                                                  multioutput=multioutput)
 
         mlops.set_stat(RegressionMetrics.MEAN_SQUARED_ERROR, data=mse)
+
+    @staticmethod
+    def mean_squared_log_error(y_true, y_pred, sample_weight=None, multioutput="uniform_average"):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        msle = sklearn.metrics.mean_squared_log_error(y_true=y_true,
+                                                      y_pred=y_pred,
+                                                      sample_weight=sample_weight,
+                                                      multioutput=multioutput)
+
+        mlops.set_stat(RegressionMetrics.MEAN_SQUARED_LOG_ERROR, data=msle)

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -11,6 +11,7 @@ from parallelm.mlops.ml_metrics_stat.classification.confusion_matrix import Conf
 from parallelm.mlops.ml_metrics_stat.regression.explained_variance_score import ExplainedVarianceScore
 from parallelm.mlops.ml_metrics_stat.regression.mean_absolute_error import MeanAbsoluteError
 from parallelm.mlops.ml_metrics_stat.regression.mean_squared_error import MeanSquaredError
+from parallelm.mlops.ml_metrics_stat.regression.mean_squared_log_error import MeanSquaredLogError
 from parallelm.mlops.mlops_exception import MLOpsException, MLOpsStatisticsException
 from parallelm.mlops.stats.bar_graph import BarGraph
 from parallelm.mlops.stats.kpi_value import KpiValue
@@ -102,6 +103,10 @@ class StatsHelper(BaseObj):
         elif name == RegressionMetrics.MEAN_SQUARED_ERROR:
             mlops_stat_object = \
                 MeanSquaredError.get_mlops_mse_stat_object(mse=data)
+
+        elif name == RegressionMetrics.MEAN_SQUARED_LOG_ERROR:
+            mlops_stat_object = \
+                MeanSquaredLogError.get_mlops_msle_stat_object(msle=data)
 
         if mlops_stat_object is not None:
             self.set_stat(name=name,

--- a/mlops/tests/test_regression_metrics.py
+++ b/mlops/tests/test_regression_metrics.py
@@ -72,6 +72,7 @@ def test_mlops_mean_absolute_error_apis():
 
     pm.done()
 
+
 def test_mlops_mean_squared_error_apis():
     pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
 
@@ -99,7 +100,47 @@ def test_mlops_mean_squared_error_apis():
 
     # testing with sample weights as well
     pm.metrics.mean_squared_error(y_true=labels_actual,
-                                   y_pred=labels_pred,
-                                   sample_weight=sample_weight)
+                                  y_pred=labels_pred,
+                                  sample_weight=sample_weight)
+
+    pm.done()
+
+
+def test_mlops_mean_squared_log_error_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1.0, 0.5, 2.5, 4.75, 7.0, 0.75]
+    labels_actual = [1.5, 0.75, 2.75, 4.5, 7.50, 0.25]
+
+    msle = sklearn.metrics.mean_squared_log_error(labels_actual, labels_pred)
+
+    # first way
+    pm.set_stat(RegressionMetrics.MEAN_SQUARED_LOG_ERROR, msle)
+
+    # second way
+    pm.metrics.mean_squared_log_error(y_true=labels_actual, y_pred=labels_pred)
+
+    # should throw error if not numeric number is provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(RegressionMetrics.MEAN_SQUARED_LOG_ERROR, [1, 2, 3])
+
+    # should throw error if labels predicted is different length than actuals
+    with pytest.raises(ValueError):
+        labels_pred_missing_values = [1.0, 0.5, 7.0, 0.75]
+        pm.metrics.mean_squared_log_error(y_true=labels_actual, y_pred=labels_pred_missing_values)
+
+    # should throw error if labels contain negative values
+    with pytest.raises(ValueError):
+        labels_pred_neg = [1.0, -0.5, 2.5, 4.75, 7.0, 0.75]
+        labels_actual_neg = [1.5, -0.75, 2.75, 4.5, 7.50, 0.25]
+
+        pm.metrics.mean_squared_log_error(y_true=labels_actual_neg, y_pred=labels_pred_neg)
+
+    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
+
+    # testing with sample weights as well
+    pm.metrics.mean_squared_log_error(y_true=labels_actual,
+                                      y_pred=labels_pred,
+                                      sample_weight=sample_weight)
 
     pm.done()


### PR DESCRIPTION
…n Squared Log Error

Usage

    labels_pred = [1.0, 0.5, 2.5, 4.75, 7.0, 0.75]
    labels_actual = [1.5, 0.75, 2.75, 4.5, 7.50, 0.25]

    msle = sklearn.metrics.mean_squared_log_error(labels_actual, labels_pred)

    # first way
    mlops.set_stat(RegressionMetrics.MEAN_SQUARED_LOG_ERROR, msle)

    # second way
    mlops.metrics.mean_squared_log_error(y_true=labels_actual, y_pred=labels_pred)

Testing Done
- Unit Test