### PR TITLE
    [REF-6034] MedianAbsoluteError: Adding MLOps Regression Metrics -…

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -19,3 +19,4 @@ class RegressionMetrics(Enum):
     MEAN_ABSOLUTE_ERROR = "Mean Absolute Error"
     MEAN_SQUARED_ERROR = "Mean Squared Error"
     MEAN_SQUARED_LOG_ERROR = "Mean Squared Log Error"
+    MEDIAN_ABSOLUTE_ERROR = "Median Absolute Error"

--- a/mlops/parallelm/mlops/ml_metrics_stat/regression/median_absolute_error.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/regression/median_absolute_error.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import RegressionMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class MedianAbsoluteError(object):
+    """
+    Responsibility of this class is basically creating stat object out of median absolute error.
+    """
+
+    @staticmethod
+    def get_mlops_mae_stat_object(mae):
+        """
+        Method will create MLOps Single value stat object from numeric real number - median absolute error
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param mae: mean absolute error
+        :return: Single Value stat object which has median absolute error embedded inside
+        """
+        single_value = None
+
+        if isinstance(mae, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(RegressionMetrics.MEDIAN_ABSOLUTE_ERROR.value) \
+                    .value(mae) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting median absolute error, mae should be of type numeric but got {}."
+                 .format(type(mae)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -141,3 +141,14 @@ class MLOpsMetrics(object):
                                                       multioutput=multioutput)
 
         mlops.set_stat(RegressionMetrics.MEAN_SQUARED_LOG_ERROR, data=msle)
+
+    @staticmethod
+    def median_absolute_error(y_true, y_pred):
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        mae = sklearn.metrics.median_absolute_error(y_true=y_true,
+                                                    y_pred=y_pred)
+
+        mlops.set_stat(RegressionMetrics.MEDIAN_ABSOLUTE_ERROR, data=mae)

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -12,6 +12,7 @@ from parallelm.mlops.ml_metrics_stat.regression.explained_variance_score import 
 from parallelm.mlops.ml_metrics_stat.regression.mean_absolute_error import MeanAbsoluteError
 from parallelm.mlops.ml_metrics_stat.regression.mean_squared_error import MeanSquaredError
 from parallelm.mlops.ml_metrics_stat.regression.mean_squared_log_error import MeanSquaredLogError
+from parallelm.mlops.ml_metrics_stat.regression.median_absolute_error import MedianAbsoluteError
 from parallelm.mlops.mlops_exception import MLOpsException, MLOpsStatisticsException
 from parallelm.mlops.stats.bar_graph import BarGraph
 from parallelm.mlops.stats.kpi_value import KpiValue
@@ -107,6 +108,10 @@ class StatsHelper(BaseObj):
         elif name == RegressionMetrics.MEAN_SQUARED_LOG_ERROR:
             mlops_stat_object = \
                 MeanSquaredLogError.get_mlops_msle_stat_object(msle=data)
+
+        elif name == RegressionMetrics.MEDIAN_ABSOLUTE_ERROR:
+            mlops_stat_object = \
+                MedianAbsoluteError.get_mlops_mae_stat_object(mae=data)
 
         if mlops_stat_object is not None:
             self.set_stat(name=name,

--- a/mlops/tests/test_regression_metrics.py
+++ b/mlops/tests/test_regression_metrics.py
@@ -144,3 +144,29 @@ def test_mlops_mean_squared_log_error_apis():
                                       sample_weight=sample_weight)
 
     pm.done()
+
+
+def test_mlops_median_absolute_error_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_pred = [1.0, 0.5, 2.5, 4.75, 7.0, 0.75]
+    labels_actual = [1.5, 0.75, 2.75, 4.5, 7.50, 0.25]
+
+    mae = sklearn.metrics.median_absolute_error(labels_actual, labels_pred)
+
+    # first way
+    pm.set_stat(RegressionMetrics.MEDIAN_ABSOLUTE_ERROR, mae)
+
+    # second way
+    pm.metrics.median_absolute_error(y_true=labels_actual, y_pred=labels_pred)
+
+    # should throw error if not numeric number is provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(RegressionMetrics.MEDIAN_ABSOLUTE_ERROR, [1, 2, 3])
+
+    # should throw error if labels predicted is different length than actuals
+    with pytest.raises(ValueError):
+        labels_pred_missing_values = [1.0, 0.5, 7.0, 0.75]
+        pm.metrics.mean_absolute_error(y_true=labels_actual, y_pred=labels_pred_missing_values)
+
+    pm.done()


### PR DESCRIPTION
… Median Absolute Error

    Usage
            labels_pred = [1.0, 0.5, 2.5, 4.75, 7.0, 0.75]
            labels_actual = [1.5, 0.75, 2.75, 4.5, 7.50, 0.25]

            mae = sklearn.metrics.median_absolute_error(labels_actual, labels_pred)

            # first way
            pm.set_stat(RegressionMetrics.MEDIAN_ABSOLUTE_ERROR, mae)

            OR

            # second way
            pm.metrics.median_absolute_error(y_true=labels_actual, y_pred=labels_pred)

    Testing Done
    - Unit Test