### PR TITLE
[REF-6034] BAScore: Adding MLOps Classification Metrics - Balanced Ac…

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -8,6 +8,7 @@ class ClassificationMetrics(Enum):
     ACCURACY_SCORE = "Accuracy Score"
     AUC = "AUC(Area Under the Curve)"
     AVERAGE_PRECISION_SCORE = "Average Precision Score"
+    BALANCED_ACCURACY_SCORE = "Balanced Accuracy Score"
     CONFUSION_MATRIX = "Confusion Matrix"
 
 

--- a/mlops/parallelm/mlops/ml_metrics_stat/classification/balanced_accuracy_score.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/classification/balanced_accuracy_score.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class BalancedAccuracyScore(object):
+    """
+    Responsibility of this class is basically creating stat object out of balanced accuracy score.
+    """
+
+    @staticmethod
+    def get_mlops_balanced_accuracy_stat_object(balanced_accuracy_score):
+        """
+        Method will create MLOps Single value stat object from numeric real number - balanced accuracy score
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param balanced_accuracy_score: numeric value of balanced accuracy
+        :return: Single Value stat object which has accuracy score embedded inside
+        """
+        single_value = None
+
+        if isinstance(balanced_accuracy_score, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(ClassificationMetrics.BALANCED_ACCURACY_SCORE.value) \
+                    .value(balanced_accuracy_score) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting balanced accuracy score, accuracy should be of type numeric but got {}."
+                 .format(type(balanced_accuracy_score)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -119,6 +119,29 @@ class MLOpsMetrics(object):
         return aps
 
     @staticmethod
+    def balanced_accuracy_score(y_true, y_pred, sample_weight=None, adjusted=False):
+        """
+
+        :param y_true: Ground truth (correct) target values.
+        :param y_pred: Estimated targets as returned by a classifier.
+        :param sample_weight: Sample weights.
+        :param adjusted: When true, the result is adjusted for chance, so that random performance would score 0, and perfect performance scores 1.
+        :return: balanced accuracy score
+        """
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        bas = sklearn.metrics.balanced_accuracy_score(y_true,
+                                                      y_pred,
+                                                      sample_weight=sample_weight,
+                                                      adjusted=adjusted)
+
+        mlops.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, data=bas)
+
+        return bas
+
+    @staticmethod
     def confusion_matrix(y_true, y_pred, labels, sample_weight=None):
         """
         Method calculates confusion matrix and output it using MCenter as table.

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -7,6 +7,7 @@ from parallelm.mlops.metrics_constants import ClassificationMetrics, RegressionM
 from parallelm.mlops.ml_metrics_stat.classification.accuracy_score import AccuracyScore
 from parallelm.mlops.ml_metrics_stat.classification.auc import AUC
 from parallelm.mlops.ml_metrics_stat.classification.average_precision_score import AveragePrecisionScore
+from parallelm.mlops.ml_metrics_stat.classification.balanced_accuracy_score import BalancedAccuracyScore
 from parallelm.mlops.ml_metrics_stat.classification.confusion_matrix import ConfusionMatrix
 from parallelm.mlops.ml_metrics_stat.regression.explained_variance_score import ExplainedVarianceScore
 from parallelm.mlops.ml_metrics_stat.regression.mean_absolute_error import MeanAbsoluteError
@@ -54,11 +55,7 @@ class StatsHelper(BaseObj):
         self._logger.debug("{} predefined stat called: name: {} data_type: {}".
                            format(Constants.OFFICIAL_NAME, name, type(data)))
 
-        if name == ClassificationMetrics.CONFUSION_MATRIX:
-            mlops_stat_object = \
-                ConfusionMatrix.get_mlops_cm_table_object(cm_nd_array=data, **kwargs)
-
-        elif name == ClassificationMetrics.ACCURACY_SCORE:
+        if name == ClassificationMetrics.ACCURACY_SCORE:
             mlops_stat_object = \
                 AccuracyScore.get_mlops_accuracy_stat_object(accuracy_score=data)
             category = StatCategory.TIME_SERIES
@@ -72,6 +69,15 @@ class StatsHelper(BaseObj):
             mlops_stat_object = \
                 AveragePrecisionScore.get_mlops_aps_stat_object(aps=data)
             category = StatCategory.TIME_SERIES
+
+        elif name == ClassificationMetrics.BALANCED_ACCURACY_SCORE:
+            mlops_stat_object = \
+                BalancedAccuracyScore.get_mlops_balanced_accuracy_stat_object(balanced_accuracy_score=data)
+            category = StatCategory.TIME_SERIES
+
+        elif name == ClassificationMetrics.CONFUSION_MATRIX:
+            mlops_stat_object = \
+                ConfusionMatrix.get_mlops_cm_table_object(cm_nd_array=data, **kwargs)
 
         if mlops_stat_object is not None:
             self.set_stat(name=name,

--- a/mlops/tests/test_classification_metrics.py
+++ b/mlops/tests/test_classification_metrics.py
@@ -63,28 +63,35 @@ def test_mlops_auc_apis():
     pm.done()
 
 
-def test_mlops_aps_apis():
+def test_mlops_bas_apis():
     pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
 
     labels_pred = [1, 0, 1, 1, 1, 0]
-    labels_decision_score = [0.9, 0.1, 0.9, 0.5, 0.1, 0.1]
+    labels_actual = [0, 1, 0, 0, 0, 1]
 
-    aps = sklearn.metrics.average_precision_score(labels_pred, labels_decision_score)
+    bas = sklearn.metrics.balanced_accuracy_score(labels_actual, labels_pred)
 
     # first way
-    pm.set_stat(ClassificationMetrics.AVERAGE_PRECISION_SCORE, aps)
+    pm.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, bas)
 
     # second way
-    pm.metrics.average_precision_score(y_true=labels_pred, y_score=labels_decision_score)
+    pm.metrics.balanced_accuracy_score(y_true=labels_actual, y_pred=labels_pred)
 
     # should throw error if not numeric number is provided
     with pytest.raises(MLOpsStatisticsException):
-        pm.set_stat(ClassificationMetrics.AVERAGE_PRECISION_SCORE, [1, 2, 3])
+        pm.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, [1, 2, 3])
 
-    # should throw error if labels decision values' length is different length than actuals
+    # should throw error if labels predicted is different length than actuals
     with pytest.raises(ValueError):
-        labels_decision_score_some_missing = [0.9, 0.1, 0.9, 0.5, 0.1]
-        pm.metrics.average_precision_score(y_true=labels_pred, y_score=labels_decision_score_some_missing)
+        labels_pred_missing_values = [0, 0, 0, 1]
+        pm.metrics.balanced_accuracy_score(y_true=labels_actual, y_pred=labels_pred_missing_values)
+
+    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
+
+    # testing with sample weights as well
+    pm.metrics.balanced_accuracy_score(y_true=labels_actual,
+                                       y_pred=labels_pred,
+                                       sample_weight=sample_weight)
 
     pm.done()
 


### PR DESCRIPTION
…curacy Score

Usages:
	labels_pred = [1, 0, 1, 1, 1, 0]
        labels_actual = [0, 1, 0, 0, 0, 1]

	bas = metrics.balanced_accuracy_score(labels_actual, labels_pred)

	# first way
	pm.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, bas)

	# second way
	pm.metrics.balanced_accuracy_score(y_true=labels_actual, y_pred=labels_pred)