### PR TITLE
[REF-6034] BrierScoreLoss: Adding MLOps Classification Metrics - Brie…

### DIFF
--- a/mlops/parallelm/mlops/metrics_constants.py
+++ b/mlops/parallelm/mlops/metrics_constants.py
@@ -9,6 +9,7 @@ class ClassificationMetrics(Enum):
     AUC = "AUC(Area Under the Curve)"
     AVERAGE_PRECISION_SCORE = "Average Precision Score"
     BALANCED_ACCURACY_SCORE = "Balanced Accuracy Score"
+    BRIER_SCORE_LOSS = "Brier Score Loss"
     CONFUSION_MATRIX = "Confusion Matrix"
 
 

--- a/mlops/parallelm/mlops/ml_metrics_stat/classification/brier_score_loss.py
+++ b/mlops/parallelm/mlops/ml_metrics_stat/classification/brier_score_loss.py
@@ -1,0 +1,33 @@
+from parallelm.mlops.metrics_constants import ClassificationMetrics
+from parallelm.mlops.mlops_exception import MLOpsStatisticsException
+from parallelm.mlops.stats.single_value import SingleValue
+from parallelm.mlops.stats_category import StatCategory
+
+
+class BrierScoreLoss(object):
+    """
+    Responsibility of this class is basically creating stat object out of brier score loss.
+    """
+
+    @staticmethod
+    def get_mlops_bsl_stat_object(bsl):
+        """
+        Method will create MLOps Single value stat object from numeric real number - brier score loss
+        It is not recommended to access this method without understanding single value data structure that it is returning.
+        :param bsl: numeric value of brier score loss
+        :return: Single Value stat object which has brier score embedded inside
+        """
+        single_value = None
+
+        if isinstance(bsl, (int, float)):
+            single_value = \
+                SingleValue() \
+                    .name(ClassificationMetrics.BRIER_SCORE_LOSS.value) \
+                    .value(bsl) \
+                    .mode(StatCategory.TIME_SERIES)
+        else:
+            raise MLOpsStatisticsException \
+                ("For outputting brier score, score should be of type numeric but got {}."
+                 .format(type(bsl)))
+
+        return single_value

--- a/mlops/parallelm/mlops/mlops_metrics.py
+++ b/mlops/parallelm/mlops/mlops_metrics.py
@@ -121,6 +121,7 @@ class MLOpsMetrics(object):
     @staticmethod
     def balanced_accuracy_score(y_true, y_pred, sample_weight=None, adjusted=False):
         """
+        Method calculates balanced accuracy and output it using MCenter.
 
         :param y_true: Ground truth (correct) target values.
         :param y_pred: Estimated targets as returned by a classifier.
@@ -140,6 +141,30 @@ class MLOpsMetrics(object):
         mlops.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, data=bas)
 
         return bas
+
+    @staticmethod
+    def brier_score_loss(y_true, y_prob, sample_weight=None, pos_label=None):
+        """
+        Method calculates brier score loss and output it using MCenter.
+
+        :param y_true: True targets.
+        :param y_prob: Probabilities of the positive class.
+        :param sample_weight: Sample weights.
+        :param pos_label: Label of the positive class. If None, the maximum label is used as positive class.
+        :return: brier score
+        """
+        # need to import only on run time.
+        from parallelm.mlops import mlops as mlops
+        import sklearn
+
+        bsl = sklearn.metrics.brier_score_loss(y_true,
+                                               y_prob,
+                                               sample_weight=sample_weight,
+                                               pos_label=pos_label)
+
+        mlops.set_stat(ClassificationMetrics.BRIER_SCORE_LOSS, data=bsl)
+
+        return bsl
 
     @staticmethod
     def confusion_matrix(y_true, y_pred, labels, sample_weight=None):

--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -8,6 +8,7 @@ from parallelm.mlops.ml_metrics_stat.classification.accuracy_score import Accura
 from parallelm.mlops.ml_metrics_stat.classification.auc import AUC
 from parallelm.mlops.ml_metrics_stat.classification.average_precision_score import AveragePrecisionScore
 from parallelm.mlops.ml_metrics_stat.classification.balanced_accuracy_score import BalancedAccuracyScore
+from parallelm.mlops.ml_metrics_stat.classification.brier_score_loss import BrierScoreLoss
 from parallelm.mlops.ml_metrics_stat.classification.confusion_matrix import ConfusionMatrix
 from parallelm.mlops.ml_metrics_stat.regression.explained_variance_score import ExplainedVarianceScore
 from parallelm.mlops.ml_metrics_stat.regression.mean_absolute_error import MeanAbsoluteError
@@ -73,6 +74,11 @@ class StatsHelper(BaseObj):
         elif name == ClassificationMetrics.BALANCED_ACCURACY_SCORE:
             mlops_stat_object = \
                 BalancedAccuracyScore.get_mlops_balanced_accuracy_stat_object(balanced_accuracy_score=data)
+            category = StatCategory.TIME_SERIES
+
+        elif name == ClassificationMetrics.BRIER_SCORE_LOSS:
+            mlops_stat_object = \
+                BrierScoreLoss.get_mlops_bsl_stat_object(bsl=data)
             category = StatCategory.TIME_SERIES
 
         elif name == ClassificationMetrics.CONFUSION_MATRIX:

--- a/mlops/tests/test_classification_metrics.py
+++ b/mlops/tests/test_classification_metrics.py
@@ -96,6 +96,39 @@ def test_mlops_bas_apis():
     pm.done()
 
 
+def test_mlops_bsl_apis():
+    pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
+
+    labels_actual = [1, 0, 1, 1, 1, 0]
+    labels_pred_prob = [0.9, 0.8, 0.7, 0.9, 0.75, 1]
+
+    bsl = sklearn.metrics.brier_score_loss(labels_actual, labels_pred_prob)
+
+    # first way
+    pm.set_stat(ClassificationMetrics.BRIER_SCORE_LOSS, bsl)
+
+    # second way
+    pm.metrics.brier_score_loss(y_true=labels_actual, y_prob=labels_pred_prob)
+
+    # should throw error if not numeric number is provided
+    with pytest.raises(MLOpsStatisticsException):
+        pm.set_stat(ClassificationMetrics.BRIER_SCORE_LOSS, [1, 2, 3])
+
+    # should throw error if labels predicted is different length than actuals
+    with pytest.raises(ValueError):
+        labels_prob_missing_values = [0, 0, 0, 1]
+        pm.metrics.brier_score_loss(y_true=labels_actual, y_prob=labels_prob_missing_values)
+
+    sample_weight = [0.9, 0.1, 0.5, 0.9, 1.0, 0]
+
+    # testing with sample weights as well
+    pm.metrics.brier_score_loss(y_true=labels_actual,
+                                y_prob=labels_pred_prob,
+                                sample_weight=sample_weight)
+
+    pm.done()
+
+
 def test_mlops_confusion_metrics_apis():
     pm.init(ctx=None, mlops_mode=MLOpsMode.STAND_ALONE)
 


### PR DESCRIPTION
…r Score Loss

Usages:
	labels_pred = [1, 0, 1, 1, 1, 0]
        labels_pred_prob = [0.9, 0.6, 0,5, 0.7, 0.9, 1]

	bsl = metrics.brier_score_loss(labels_actual, labels_pred_prob)

	# first way
	pm.set_stat(ClassificationMetrics.BRIER_SCORE_LOSS, bsl)

	# second way
	pm.metrics.brier_score_loss(y_true=labels_actual, y_prob=labels_pred_prob)

Testing Done
 - Unit Test