### PR TITLE
[REF-6108] open text files using utf-8 encoding

### DIFF
--- a/mlcomp/CHANGELOG.md
+++ b/mlcomp/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - added quickstart section to readme
 
+### Fixed
+- [REF-6108] explicitly specify utf-8 encoding when opening text file
+
 ## [1.2.1] - 2019-04-22
 ### Added
 - include all Java standalone/connected component's jars into classpath
@@ -26,3 +29,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 ### Removed
 ### Deprecated
+

--- a/mlcomp/parallelm/pipeline/components_desc.py
+++ b/mlcomp/parallelm/pipeline/components_desc.py
@@ -1,3 +1,4 @@
+import io
 import json
 import pkg_resources
 import os
@@ -36,7 +37,7 @@ class ComponentsDesc(Base):
     def _load_comp_desc(root, filename):
         if filename.endswith(".json"):
             comp_json = os.path.join(root, filename)
-            with open(comp_json) as f:
+            with io.open(comp_json, encoding="utf-8") as f:
                 try:
                     comp_desc = json.load(f)
                 except ValueError as ex:
@@ -63,7 +64,7 @@ class ComponentsDesc(Base):
 
         components_desc = self.load(extended=False)
 
-        with open(out_file_path, 'w') as f:
+        with io.open(out_file_path, mode='w', encoding="utf-8") as f:
             json.dump(components_desc, f, indent=4)
             print("Components details were written successfully to: " + out_file_path)
 

--- a/mlcomp/tests/test_mlpiper_cmdline.py
+++ b/mlcomp/tests/test_mlpiper_cmdline.py
@@ -101,6 +101,20 @@ deps_show_pipeline = {
     ]
 }
 
+parse_pipeline_with_unicode_symbol_in_component = {
+    "name": "Parse Pipeline with unicode ",
+    "engineType": "Generic",
+    "pipe": [
+        {
+            "name": "Test source model",
+            "id": 1,
+            "type": "test-component-with-unicode",
+            "parents": [],
+            "arguments": {}
+        }
+    ]
+}
+
 java_connected_pipeline = {
     "name": "connected_with_multiple_jars_test",
     "engineType": "Generic",
@@ -263,6 +277,22 @@ class TestMLPiper:
             assert ("dep2" in l_deps)
             assert ("dep345" in l_deps)
             assert ("dep456" in l_deps)
+        finally:
+            os.remove(pipeline_file)
+
+
+    def test_parse_component_with_unicode_symbol(self):
+        cmdline_action = "deps"
+        comp_dir = os.path.join(os.path.dirname(__file__), PYTHON_COMPONENTS_PATH)
+
+        fd, pipeline_file = mkstemp(prefix='test_component_with_unicode_', dir='/tmp')
+        os.write(fd, json.dumps(parse_pipeline_with_unicode_symbol_in_component).encode())
+        os.close(fd)
+
+        cmd = "{} {} -r {} -f {} Python".format(TestMLPiper.mlpiper_script, cmdline_action, comp_dir,
+                                                pipeline_file)
+        try:
+            stdout, stderr = self._exec_shell_cmd(cmd, "Failed in '{}' mlpiper command line! {}".format(cmdline_action, cmd))
         finally:
             os.remove(pipeline_file)
 

--- a/reflex-algos/components/Python/test-component-with-unicode/component.json
+++ b/reflex-algos/components/Python/test-component-with-unicode/component.json
@@ -1,0 +1,16 @@
+{
+  "engineType": "Generic",
+  "userStandalone": false,
+  "language": "Python",
+  "name": "test-component-with-unicode",
+  "label": "unicode symbol: ’",
+  "deps": ["dep1", "dep2"],
+  "program": "",
+  "componentClass": "No Class",
+  "group": "Sinks",
+  "useMLOps": true,
+  "inputInfo": [],
+  "outputInfo": [],
+  "arguments": [],
+  "version": 1
+}


### PR DESCRIPTION
When opening file in text mode, default encoding is platform dependent
and defined by locale.getpreferredencoding(). If default is ascii,
decoding fails on unicode symbols.

It is recommended to explicitly use utf-8 when opening a file (or open
file in binary mode and then decode)

Python2 open() method doesn't support encoding argument, so it is
recommended to use io.open().