### PR TITLE
fix Py3.8 deprecation warnings

### DIFF
--- a/mlops/parallelm/mlops/stats/stats_helper.py
+++ b/mlops/parallelm/mlops/stats/stats_helper.py
@@ -118,20 +118,20 @@ class StatsHelper(BaseObj):
             self._output_channel.stat_object(data.get_mlops_stat(model_id))
             return self
 
-        if name in ClassificationMetrics:
+        if isinstance(name, ClassificationMetrics):
             self._set_classification_stat(name=name,
                                           data=data,
                                           model_id=model_id,
                                           timestamp=timestamp, **kwargs)
 
             return self
-        elif name in RegressionMetrics:
+        elif isinstance(name, RegressionMetrics):
             self._set_regression_stat(name=name,
                                       data=data,
                                       model_id=model_id,
                                       timestamp=timestamp, **kwargs)
             return self
-        elif name in ClusteringMetrics:
+        elif isinstance(name, ClusteringMetrics):
             self._set_clustering_stat(name=name,
                                       data=data,
                                       model_id=model_id,


### PR DESCRIPTION
DeprecationWarning: using non-Enums in containment checks will raise TypeError in Python 3.8
set_stat is used as following:
mlops.set_stat("stat_name",...)
mlops.set_stat(ClassificationMetrics.ACCURACY_SCORE, data=accuracy_score)

for the first case the check:
if name in ClassificationMetrics

causes the warning.