### PR TITLE
clean up mlops/mlcomp/deputy makefile

### DIFF
--- a/deputy/Makefile
+++ b/deputy/Makefile
@@ -9,10 +9,12 @@ DEPUTY_EGG_PY3 = $(shell realpath $(shell ls ./dist/*-py3.*.egg))
 DEPUTY_EGG_PY2_BASENAME = $(shell basename $(DEPUTY_EGG_PY2))
 DEPUTY_EGG_PY3_BASENAME = $(shell basename $(DEPUTY_EGG_PY3))
 
-egg:
+egg local:
 	rm -rf ./dist
 	python2 setup.py bdist_egg
 	python3 setup.py bdist_egg
+	cd dist; ln -sf $(DEPUTY_EGG_PY2_BASENAME) $(DEPUTY_EGG_PY2_SYMLINK); cd -
+	cd dist; ln -sf $(DEPUTY_EGG_PY3_BASENAME) $(DEPUTY_EGG_PY3_SYMLINK); cd -
 
 install_to: egg
 ifneq ($(DISTDIR),"")
@@ -30,11 +32,6 @@ bdist:
 test: egg
 	env PYTHONPATH=./:tests/ python2 -m py.test -v tests/
 	env PYTHONPATH=./:tests/ python3 -m pytest -v tests/
-
-# Creating the softlinks inside the deputy dist dir
-local: egg
-	cd dist; ln -sf $(DEPUTY_EGG_PY2_BASENAME) $(DEPUTY_EGG_PY2_SYMLINK); cd -
-	cd dist; ln -sf $(DEPUTY_EGG_PY3_BASENAME) $(DEPUTY_EGG_PY3_SYMLINK); cd -
 
 run: egg
 	./bin/run-deputy.sh

--- a/mlcomp/Makefile
+++ b/mlcomp/Makefile
@@ -2,21 +2,31 @@
 
 DISTDIR = ""
 
+MLCOMP_EGG_PY2 = $(shell realpath $(shell ls ./dist/*-py2.*.egg))
+MLCOMP_EGG_PY3 = $(shell realpath $(shell ls ./dist/*-py3.*.egg))
+
+MLCOMP_EGG_PY2_BASENAME = $(shell basename $(MLCOMP_EGG_PY2))
+MLCOMP_EGG_PY3_BASENAME = $(shell basename $(MLCOMP_EGG_PY3))
+
 MLCOMP_EGG_PY2_SYMLINK = "mlcomp-py2.egg"
 MLCOMP_EGG_PY3_SYMLINK = "mlcomp-py3.egg"
+
+MLOPS_EGG_PY2 = $(shell realpath $(shell ls ../mlops/dist/*-py2.*.egg))
+MLOPS_EGG_PY3 = $(shell realpath $(shell ls ../mlops/dist/*-py3.*.egg))
+COMP_EGG_PY2 = $(shell realpath $(shell ls /tmp/python_mcenter_components*-py2.*.egg))
+COMP_EGG_PY3 = $(shell realpath $(shell ls /tmp/python_mcenter_components*-py3.*.egg))
+SPARK_JARS = "../reflex-algos/target/ReflexAlgos-jar-with-dependencies.jar"
+
+egg local:
+	rm -rf ./dist
+	python2 setup.py -q bdist_egg
+	python3 setup.py -q bdist_egg
+	cd dist; ln -sf $(MLCOMP_EGG_PY2_BASENAME) $(MLCOMP_EGG_PY2_SYMLINK); cd -
+	cd dist; ln -sf $(MLCOMP_EGG_PY3_BASENAME) $(MLCOMP_EGG_PY3_SYMLINK); cd -
 
 bdist:
 	python setup.py bdist
 
-egg:
-	rm -rf ./dist
-	python2 setup.py -q bdist_egg
-	python3 setup.py -q bdist_egg
-
-MLCOMP_EGG_PY2 = $(shell realpath $(shell ls ./dist/*-py2.*.egg))
-MLCOMP_EGG_PY3 = $(shell realpath $(shell ls ./dist/*-py3.*.egg))
-MLCOMP_EGG_PY2_BASENAME = $(shell basename $(MLCOMP_EGG_PY2))
-MLCOMP_EGG_PY3_BASENAME = $(shell basename $(MLCOMP_EGG_PY3))
 
 install_to: egg
 ifneq ($(DISTDIR),"")
@@ -47,25 +57,12 @@ comp_eggs: python_comps_egg pyspark_comps_egg
 mlops_egg:
 	cd ../mlops ; make egg; cd -
 
-MLCOMP_EGG_PY2 = $(shell realpath $(shell ls dist/*-py2.*.egg))
-MLCOMP_EGG_PY3 = $(shell realpath $(shell ls dist/*-py3.*.egg))
-MLOPS_EGG_PY2 = $(shell realpath $(shell ls ../mlops/dist/*-py2.*.egg))
-MLOPS_EGG_PY3 = $(shell realpath $(shell ls ../mlops/dist/*-py3.*.egg))
-COMP_EGG_PY2 = $(shell realpath $(shell ls /tmp/python_mcenter_components*-py2.*.egg))
-COMP_EGG_PY3 = $(shell realpath $(shell ls /tmp/python_mcenter_components*-py3.*.egg))
-SPARK_JARS = "../reflex-algos/target/ReflexAlgos-jar-with-dependencies.jar"
-
 test: egg mlops_egg comp_eggs
 	# Running the tests with the python egg
 	env PYTHONPATH=$(MLCOMP_EGG_PY2):$(MLOPS_EGG_PY2):$(COMP_EGG_PY2):tests SPARK_JARS=$(SPARK_JARS) python2 -m py.test tests/
 	env PYTHONPATH=$(MLCOMP_EGG_PY3):$(MLOPS_EGG_PY3):$(COMP_EGG_PY3):tests SPARK_JARS=$(SPARK_JARS) python3 -m pytest tests/
 
 	# TODO: add running tests for pyspark components
-
-local: egg
-	cd dist; ln -sf $(MLCOMP_EGG_PY2_BASENAME) $(MLCOMP_EGG_PY2_SYMLINK); cd -
-	cd dist; ln -sf $(MLCOMP_EGG_PY3_BASENAME) $(MLCOMP_EGG_PY3_SYMLINK); cd -
-
 
 install: wheel
 	env PYTHONPATH=./ bin/install_locally.py

--- a/mlops/Makefile
+++ b/mlops/Makefile
@@ -13,31 +13,37 @@ DISTDIR = ""
 MLOPS_EGG_PY2_SYMLINK = "mlops-py2.egg"
 MLOPS_EGG_PY3_SYMLINK = "mlops-py3.egg"
 
-# Put it first so that "make" without argument is like "make help".
+MLOPS_EGG_PY2 = $(shell realpath $(shell ls ./dist/*-py2.*.egg))
+MLOPS_EGG_PY3 = $(shell realpath $(shell ls ./dist/*-py3.*.egg))
+MLOPS_EGG_PY2_BASENAME = $(shell basename $(MLOPS_EGG_PY2))
+MLOPS_EGG_PY3_BASENAME = $(shell basename $(MLOPS_EGG_PY3))
+SPARK_JARS = "../reflex-algos/target/ReflexAlgos-jar-with-dependencies.jar"
+
+# Put these as the first targets, so that "make" without argument is like "make egg".
+# TODO: `local` target is for compatibility only and should be removed once other code is cleaned up.
+egg local:
+	rm -rf ./dist
+	python2 setup.py -q bdist_egg
+	python3 setup.py -q bdist_egg
+	cd dist; ln -sf $(MLOPS_EGG_PY2_BASENAME) $(MLOPS_EGG_PY2_SYMLINK); cd -
+	cd dist; ln -sf $(MLOPS_EGG_PY3_BASENAME) $(MLOPS_EGG_PY3_SYMLINK); cd -
+
+bdist:
+	python setup.py bdist
+
+
+# show help for sphinx
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile bdist
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+.PHONY: help Makefile bdist
 
-bdist:
-	python setup.py bdist
-
-egg:
-	rm -rf ./dist
-	python2 setup.py -q bdist_egg
-	python3 setup.py -q bdist_egg
-
-MLOPS_EGG_PY2 = $(shell realpath $(shell ls ./dist/*-py2.*.egg))
-MLOPS_EGG_PY3 = $(shell realpath $(shell ls ./dist/*-py3.*.egg))
-MLOPS_EGG_PY2_BASENAME = $(shell basename $(MLOPS_EGG_PY2))
-MLOPS_EGG_PY3_BASENAME = $(shell basename $(MLOPS_EGG_PY3))
-SPARK_JARS = "../reflex-algos/target/ReflexAlgos-jar-with-dependencies.jar"
 
 install_to: egg
 ifneq ($(DISTDIR),"")
@@ -46,11 +52,6 @@ ifneq ($(DISTDIR),"")
 	cd $(DISTDIR); ln -sf $(MLOPS_EGG_PY2_BASENAME) $(MLOPS_EGG_PY2_SYMLINK); cd -
 	cd $(DISTDIR); ln -sf $(MLOPS_EGG_PY3_BASENAME) $(MLOPS_EGG_PY3_SYMLINK); cd -
 endif
-
-local: egg
-	cd dist; ln -sf $(MLOPS_EGG_PY2_BASENAME) $(MLOPS_EGG_PY2_SYMLINK); cd -
-	cd dist; ln -sf $(MLOPS_EGG_PY3_BASENAME) $(MLOPS_EGG_PY3_SYMLINK); cd -
-
 
 wheel:
 	python2 setup.py sdist bdist_wheel


### PR DESCRIPTION
- move egg to the top, so it is default target taken by 'make' command
- create symlinks together with eggs, so it would be more convenient to
run manually - just `make`