### PR TITLE
mlcomp: bg_actor: rename _stop flag as the same name is used in py Thread class

### DIFF
--- a/mlcomp/parallelm/common/bg_actor.py
+++ b/mlcomp/parallelm/common/bg_actor.py
@@ -18,13 +18,13 @@ class BgActor(with_metaclass(abc.ABCMeta, Base, threading.Thread)):
         self._polling_interval_sec = polling_interval_sec
 
         self._condition = threading.Condition()
-        self._stop = False
+        self._stop_gracefully = False
 
     def run(self):
         while True:
             with self._condition:
                 self._condition.wait(self._polling_interval_sec)
-                if self._mlops.done_called or self._stop:
+                if self._mlops.done_called or self._stop_gracefully:
                     break
 
             self._do_repetitive_work()
@@ -34,7 +34,7 @@ class BgActor(with_metaclass(abc.ABCMeta, Base, threading.Thread)):
     def stop_gracefully(self):
         with self._condition:
             self._finalize()
-            self._stop = True
+            self._stop_gracefully = True
             self._condition.notify_all()
 
     @abc.abstractmethod


### PR DESCRIPTION
Started to see the following error:
```
Exception ignored in: <module 'threading' from '/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py'>
421 Traceback (most recent call last):
422   File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 1281, in _shutdown
423     t.join()
424   File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 1032, in join
425     self._wait_for_tstate_lock()
426   File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 1050, in _wait_for_tstate_lock
427     self._stop()
428 TypeError: 'bool' object is not callable
429 End of go
```

Found out that there is `_stop()` in Thread class.
And BgActor class was defining  boolean `_stop` variable