### PR TITLE
Bug fix: parent's output placeholder was overwritten

### DIFF
--- a/mlcomp/parallelm/mlcomp/__init__.py
+++ b/mlcomp/parallelm/mlcomp/__init__.py
@@ -1,5 +1,5 @@
 
-version = "1.3.1"
+version = "1.3.2"
 __version__ = version
 project_name = "ml-comp"
 symlink_name = "mlcomp"

--- a/mlcomp/parallelm/pipeline/dag.py
+++ b/mlcomp/parallelm/pipeline/dag.py
@@ -228,11 +228,16 @@ class Dag(Base):
             parent_id = connector[json_fields.PIPELINE_COMP_PARENTS_FIRST_FIELD]
             output_index = connector[json_fields.PIPELINE_COMP_PARENTS_SECOND_FIELD]
 
-            if parent_id in self._parent_data_objs_placeholder and \
-                    output_index not in self._parent_data_objs_placeholder[parent_id]:
-                self._logger.debug("An entry already exists in data objs placeholder, parend_id={}, output_id={}"
-                                   .format(parent_id, output_index))
-                self._parent_data_objs_placeholder[parent_id][output_index] = None
+            if parent_id in self._parent_data_objs_placeholder:
+                if output_index not in self._parent_data_objs_placeholder[parent_id]:
+                    self._logger.debug("An entry already exists in data objs placeholder, parend_id={}, output_id={}"
+                                       .format(parent_id, output_index))
+                    self._parent_data_objs_placeholder[parent_id][output_index] = None
+                else:
+                    self._logger.debug(
+                        "An entry already exists along with output index in data objs placeholder, "
+                        "parend_id={}, output_id={}".format(parent_id, output_index)
+                    )
             else:
                 self._logger.debug("Adding an entry in data objs placeholder ... parent_id={}, output_index={}"
                                    .format(parent_id, output_index))


### PR DESCRIPTION
A parent node's output placeholder was overwritten in the following pipeline structure:

A[Output-0] ==> B[Input-0] ==> C[Input-0]
A[Output-1] ==> B[Input-1]
A[Output-1] ==============> C[Input-1]